### PR TITLE
feat(x): add support for x lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ uv run laminar scan --source youtube
 uv run laminar stats
 ```
 
-`laminar source add` always takes the source URL as a positional argument. When `--type` is omitted, Laminar infers X URLs as `x`, YouTube URLs as `youtube`, and treats everything else as `feed`. If you pass `--type`, that explicit value wins. For now, the user-facing CLI only exposes `feed`, `youtube`, and `x`. Every option in `laminar source add --help` includes a description so the command is easier to discover.
+`laminar source add` always takes the source URL as a positional argument. When `--type` is omitted, Laminar infers X URLs as `x`, YouTube feed URLs as `youtube`, and treats everything else as `feed`. If you pass `--type`, that explicit value wins. For now, the user-facing CLI only exposes `feed`, `youtube`, and `x`. Every option in `laminar source add --help` includes a description so the command is easier to discover.
 
 X sources are treated as paid by default, including when the type is inferred from an X URL. Use `--paid` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ By default, Laminar keeps its state under `~/.laminar/`:
 ```bash
 uv sync
 uv run laminar source validate
-uv run laminar source add --kind feed --label "SCMP News" --feed-url https://www.scmp.com/rss/4/feed/
+uv run laminar source add --name "SCMP News" https://www.scmp.com/rss/4/feed/
 uv run laminar scan
 uv run laminar stats
 uv run laminar items list
@@ -30,10 +30,10 @@ database_path: laminar.db
 Add sources through the CLI:
 
 ```bash
-uv run laminar source add --kind feed --label "SCMP News" --feed-url https://www.scmp.com/rss/4/feed/
-uv run laminar source add --kind youtube --label "Example Channel" --feed-url "https://www.youtube.com/feeds/videos.xml?channel_id=..." --transcript-language en
-uv run laminar source add --kind x --label "Example on X" --command xurl https://api.x.com/2/...
-uv run laminar source add --kind x --label "AI Researchers" --feed-url https://x.com/i/lists/1234567890
+uv run laminar source add --name "SCMP News" https://www.scmp.com/rss/4/feed/
+uv run laminar source add --name "Example Channel" "https://www.youtube.com/feeds/videos.xml?channel_id=..." --transcript-language en
+uv run laminar source add --name "Example on X" https://x.com/example
+uv run laminar source add --name "AI Researchers" https://x.com/i/lists/1234567890
 uv run laminar source show SOURCE_ID
 uv run laminar source remove SOURCE_ID
 uv run laminar source remove --recursive SOURCE_ID
@@ -45,9 +45,11 @@ uv run laminar scan --source youtube
 uv run laminar stats
 ```
 
-X sources are treated as paid by default. Use `--costs-money` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
+`laminar source add` always takes the source URL as a positional argument. When `--type` is omitted, Laminar infers X URLs as `x`, YouTube URLs as `youtube`, and treats everything else as `feed`. If you pass `--type`, that explicit value wins. For now, the user-facing CLI only exposes `feed`, `youtube`, and `x`. Every option in `laminar source add --help` includes a description so the command is easier to discover.
 
-For `--kind x`, Laminar can either run an explicit `--command` or resolve `--feed-url` through `xurl` automatically. For X list browser URLs like `https://x.com/i/lists/...`, Laminar translates them into the corresponding list-tweets API request before invoking `xurl`, then normalizes each returned post into the database as an `x_post` item.
+X sources are treated as paid by default, including when the type is inferred from an X URL. Use `--paid` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
+
+For X sources, Laminar resolves the source URL through `xurl` automatically. X list browser URLs like `https://x.com/i/lists/...` are detected automatically and translated into the corresponding list-tweets API request before invoking `xurl`; other X URLs are treated as user sources.
 
 `laminar source remove` deletes the source definition and its scan history. Pass `--recursive` if you also want to delete all items already ingested from that source.
 
@@ -57,6 +59,6 @@ For `--kind x`, Laminar can either run an explicit `--command` or resolve `--fee
 
 Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 
-`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed and YouTube scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command or resolved `xurl` target and then filter out items at or before the last successful scan time locally.
+`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed and YouTube scans assume reverse-chronological ordering and stop once they reach older entries; X scans invoke `xurl` for the configured source URL and then filter out items at or before the last successful scan time locally.
 
 `laminar stats` shows an overview of total sources and items, plus approximate logical item size derived from the text stored in SQLite. It also groups counts and size by source kind and by individual source.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Laminar logo](assets/laminar-logo.png)
 
-Laminar is a local-first CLI for ingesting updates from blogs, YouTube channels, X accounts, and X lists into SQLite for deterministic retrieval by a downstream agent.
+Laminar is a local-first CLI for ingesting updates from feeds, YouTube channels, X accounts, and X lists into SQLite for deterministic retrieval by a downstream agent.
 
 By default, Laminar keeps its state under `~/.laminar/`:
 - `~/.laminar/laminar.db`
@@ -13,7 +13,7 @@ By default, Laminar keeps its state under `~/.laminar/`:
 ```bash
 uv sync
 uv run laminar source validate
-uv run laminar source add --kind blog --label "Example Blog" --feed-url https://example.com/feed.xml
+uv run laminar source add --kind feed --label "SCMP News" --feed-url https://www.scmp.com/rss/4/feed/
 uv run laminar scan
 uv run laminar items list
 ```
@@ -29,7 +29,7 @@ database_path: laminar.db
 Add sources through the CLI:
 
 ```bash
-uv run laminar source add --kind blog --label "Example Blog" --feed-url https://example.com/feed.xml
+uv run laminar source add --kind feed --label "SCMP News" --feed-url https://www.scmp.com/rss/4/feed/
 uv run laminar source add --kind youtube --label "Example Channel" --feed-url "https://www.youtube.com/feeds/videos.xml?channel_id=..." --transcript-language en
 uv run laminar source add --kind x --label "Example on X" --command xurl https://api.x.com/2/...
 uv run laminar source add --kind x --label "AI Researchers" --feed-url https://x.com/i/lists/1234567890
@@ -52,4 +52,4 @@ For `--kind x`, Laminar can either run an explicit `--command` or resolve `--fee
 
 Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 
-`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Blog and YouTube feed scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command or resolved `xurl` target and then filter out items at or before the last successful scan time locally.
+`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed and YouTube scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command or resolved `xurl` target and then filter out items at or before the last successful scan time locally.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ uv run laminar source remove --recursive SOURCE_ID
 uv run laminar items remove ITEM_ID
 uv run laminar source list
 uv run laminar scan --include-paid
+uv run laminar scan -i -v
 uv run laminar scan --source youtube
 ```
 
@@ -48,5 +49,7 @@ For `--kind x`, Laminar can either run an explicit `--command` or resolve `--fee
 `laminar source remove` deletes the source definition and its scan history. Pass `--recursive` if you also want to delete all items already ingested from that source.
 
 `laminar items remove` deletes a single stored item and its associated stored content. Like `items show`, it accepts an exact item ID, a unique item ID prefix, or a unique title.
+
+Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 
 `laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Blog and YouTube feed scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command or resolved `xurl` target and then filter out items at or before the last successful scan time locally.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Laminar
 
+> Never look at an algorithmic feed that you don't control again
+
 ![Laminar logo](assets/laminar-logo.png)
 
 Laminar is a local-first CLI for ingesting updates from feeds, YouTube channels, X accounts, and X lists into SQLite for deterministic retrieval by a downstream agent.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ uv sync
 uv run laminar source validate
 uv run laminar source add --kind feed --label "SCMP News" --feed-url https://www.scmp.com/rss/4/feed/
 uv run laminar scan
+uv run laminar stats
 uv run laminar items list
 ```
 
@@ -33,6 +34,7 @@ uv run laminar source add --kind feed --label "SCMP News" --feed-url https://www
 uv run laminar source add --kind youtube --label "Example Channel" --feed-url "https://www.youtube.com/feeds/videos.xml?channel_id=..." --transcript-language en
 uv run laminar source add --kind x --label "Example on X" --command xurl https://api.x.com/2/...
 uv run laminar source add --kind x --label "AI Researchers" --feed-url https://x.com/i/lists/1234567890
+uv run laminar source show SOURCE_ID
 uv run laminar source remove SOURCE_ID
 uv run laminar source remove --recursive SOURCE_ID
 uv run laminar items remove ITEM_ID
@@ -40,6 +42,7 @@ uv run laminar source list
 uv run laminar scan --include-paid
 uv run laminar scan -i -v
 uv run laminar scan --source youtube
+uv run laminar stats
 ```
 
 X sources are treated as paid by default. Use `--costs-money` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
@@ -48,8 +51,12 @@ For `--kind x`, Laminar can either run an explicit `--command` or resolve `--fee
 
 `laminar source remove` deletes the source definition and its scan history. Pass `--recursive` if you also want to delete all items already ingested from that source.
 
+`laminar source show` prints the stored details for a single source as JSON, including its config fields, last successful scan timestamp, item count, and logical item size.
+
 `laminar items remove` deletes a single stored item and its associated stored content. Like `items show`, it accepts an exact item ID, a unique item ID prefix, or a unique title.
 
 Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 
 `laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed and YouTube scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command or resolved `xurl` target and then filter out items at or before the last successful scan time locally.
+
+`laminar stats` shows an overview of total sources and items, plus approximate logical item size derived from the text stored in SQLite. It also groups counts and size by source kind and by individual source.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Laminar logo](assets/laminar-logo.png)
 
-Laminar is a local-first CLI for ingesting updates from blogs, YouTube channels, and X accounts into SQLite for deterministic retrieval by a downstream agent.
+Laminar is a local-first CLI for ingesting updates from blogs, YouTube channels, X accounts, and X lists into SQLite for deterministic retrieval by a downstream agent.
 
 By default, Laminar keeps its state under `~/.laminar/`:
 - `~/.laminar/laminar.db`
@@ -32,6 +32,10 @@ Add sources through the CLI:
 uv run laminar source add --kind blog --label "Example Blog" --feed-url https://example.com/feed.xml
 uv run laminar source add --kind youtube --label "Example Channel" --feed-url "https://www.youtube.com/feeds/videos.xml?channel_id=..." --transcript-language en
 uv run laminar source add --kind x --label "Example on X" --command xurl https://api.x.com/2/...
+uv run laminar source add --kind x --label "AI Researchers" --feed-url https://x.com/i/lists/1234567890
+uv run laminar source remove SOURCE_ID
+uv run laminar source remove --recursive SOURCE_ID
+uv run laminar items remove ITEM_ID
 uv run laminar source list
 uv run laminar scan --include-paid
 uv run laminar scan --source youtube
@@ -39,4 +43,10 @@ uv run laminar scan --source youtube
 
 X sources are treated as paid by default. Use `--costs-money` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
 
-`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Blog and YouTube feed scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command and then filter out items at or before the last successful scan time locally.
+For `--kind x`, Laminar can either run an explicit `--command` or resolve `--feed-url` through `xurl` automatically. For X list browser URLs like `https://x.com/i/lists/...`, Laminar translates them into the corresponding list-tweets API request before invoking `xurl`, then normalizes each returned post into the database as an `x_post` item.
+
+`laminar source remove` deletes the source definition and its scan history. Pass `--recursive` if you also want to delete all items already ingested from that source.
+
+`laminar items remove` deletes a single stored item and its associated stored content. Like `items show`, it accepts an exact item ID, a unique item ID prefix, or a unique title.
+
+`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Blog and YouTube feed scans assume reverse-chronological ordering and stop once they reach older entries; X scans currently still invoke the configured command or resolved `xurl` target and then filter out items at or before the last successful scan time locally.

--- a/src/laminar/adapters.py
+++ b/src/laminar/adapters.py
@@ -7,7 +7,6 @@ from typing import Callable, Protocol
 from urllib.parse import parse_qsl, urlencode, urlparse
 from xml.etree import ElementTree
 
-from laminar.config import normalize_source_kind
 from laminar.fetch import fetch_text
 from laminar.models import NormalizedItem, SourceConfig
 from laminar.youtube import (
@@ -273,7 +272,7 @@ class XAdapter:
 
 
 def build_adapter(source: SourceConfig) -> Adapter:
-    kind = normalize_source_kind(source.kind)
+    kind = source.kind
     if kind == "feed":
         return FeedAdapter()
     if kind == "youtube":
@@ -321,15 +320,13 @@ def _run_x_command(
     *,
     verbose: Callable[[str], None] | None = None,
 ) -> str:
-    command = source.command[:]
-    if not command:
-        if source.feed_url:
-            command = ["xurl", _x_command_target(source.feed_url)]
-        else:
-            api_url = source.metadata.get("api_url")
-            if not isinstance(api_url, str) or not api_url:
-                raise ValueError(f"Source {source.id}: missing x command target")
-            command = ["xurl", api_url]
+    if source.feed_url:
+        command = ["xurl", _x_command_target(source.feed_url)]
+    else:
+        api_url = source.metadata.get("api_url")
+        if not isinstance(api_url, str) or not api_url:
+            raise ValueError(f"Source {source.id}: missing x command target")
+        command = ["xurl", api_url]
     _verbose_log(verbose, f"{source.id}: running x command {' '.join(command)}")
 
     result = subprocess.run(

--- a/src/laminar/adapters.py
+++ b/src/laminar/adapters.py
@@ -4,6 +4,7 @@ import json
 import subprocess
 from datetime import datetime, timezone
 from typing import Protocol
+from urllib.parse import parse_qsl, urlencode, urlparse
 from xml.etree import ElementTree
 
 from laminar.fetch import fetch_text
@@ -201,35 +202,21 @@ class XAdapter:
     ) -> list[NormalizedItem]:
         payload = _run_x_command(source)
         data = json.loads(payload)
-        tweets = data.get("data") if isinstance(data, dict) else data
-        if not isinstance(tweets, list):
+        tweets = _extract_x_tweets(data)
+        if tweets is None:
             raise ValueError(
-                f"Source {source.id}: x payload must be a JSON list or object with data[]"
+                f"Source {source.id}: x payload must contain tweet-like objects"
             )
 
-        includes = data.get("includes", {}) if isinstance(data, dict) else {}
-        users = {
-            user.get("id"): user.get("username")
-            for user in includes.get("users", [])
-            if isinstance(user, dict)
-        }
+        users = _extract_x_users(data)
 
         items: list[NormalizedItem] = []
         for tweet in tweets:
-            if not isinstance(tweet, dict):
-                continue
-            tweet_id = str(tweet.get("id")) if tweet.get("id") is not None else None
-            author_id = (
-                str(tweet.get("author_id"))
-                if tweet.get("author_id") is not None
-                else None
-            )
-            username = users.get(author_id) or source.handle
-            canonical_url = None
-            if username and tweet_id:
-                canonical_url = f"https://x.com/{username}/status/{tweet_id}"
-            text = tweet.get("text")
-            published_at = _parse_dt(tweet.get("created_at"))
+            tweet_id = _string_value(tweet.get("id"))
+            username = _tweet_username(tweet, users) or source.handle
+            canonical_url = _tweet_canonical_url(tweet, tweet_id, username)
+            text = _tweet_text(tweet)
+            published_at = _parse_dt(_tweet_created_at(tweet))
             if since and published_at and published_at <= since:
                 continue
             items.append(
@@ -296,10 +283,13 @@ def _parse_dt(value: str | None) -> datetime | None:
 def _run_x_command(source: SourceConfig) -> str:
     command = source.command[:]
     if not command:
-        api_url = source.metadata.get("api_url")
-        if not isinstance(api_url, str) or not api_url:
-            raise ValueError(f"Source {source.id}: missing api_url")
-        command = ["xurl", api_url]
+        if source.feed_url:
+            command = ["xurl", _x_command_target(source.feed_url)]
+        else:
+            api_url = source.metadata.get("api_url")
+            if not isinstance(api_url, str) or not api_url:
+                raise ValueError(f"Source {source.id}: missing x command target")
+            command = ["xurl", api_url]
 
     result = subprocess.run(
         command,
@@ -315,3 +305,153 @@ def _title_from_text(text: str | None) -> str:
         return "(untitled x post)"
     line = " ".join(text.split())
     return line[:72] + ("..." if len(line) > 72 else "")
+
+
+def _x_command_target(feed_url: str) -> str:
+    parsed = urlparse(feed_url)
+    if parsed.scheme in {"http", "https"} and parsed.netloc.endswith("x.com"):
+        path_parts = [part for part in parsed.path.split("/") if part]
+        if len(path_parts) >= 3 and path_parts[0] == "i" and path_parts[1] == "lists":
+            list_id = path_parts[2]
+            params = dict(parse_qsl(parsed.query, keep_blank_values=False))
+            params.setdefault("max_results", "100")
+            params.setdefault("expansions", "author_id")
+            params.setdefault("tweet.fields", "created_at")
+            params.setdefault("user.fields", "username")
+            return f"/2/lists/{list_id}/tweets?{urlencode(sorted(params.items()))}"
+    return feed_url
+
+
+def _extract_x_tweets(data: object) -> list[dict[str, object]] | None:
+    if isinstance(data, list):
+        return _coerce_x_tweets(data)
+
+    if not isinstance(data, dict):
+        return None
+
+    for key in ("data", "items", "tweets"):
+        value = data.get(key)
+        if isinstance(value, list):
+            return _coerce_x_tweets(value)
+
+    if _looks_like_x_tweet(data):
+        return [data]
+    return None
+
+
+def _extract_x_users(data: object) -> dict[str, str]:
+    if not isinstance(data, dict):
+        return {}
+    includes = data.get("includes", {})
+    if not isinstance(includes, dict):
+        return {}
+
+    users: dict[str, str] = {}
+    raw_users = includes.get("users", [])
+    if not isinstance(raw_users, list):
+        return users
+
+    for user in raw_users:
+        if not isinstance(user, dict):
+            continue
+        user_id = _string_value(user.get("id"))
+        username = _string_value(user.get("username")) or _string_value(
+            user.get("screen_name")
+        )
+        if user_id and username:
+            users[user_id] = username
+    return users
+
+
+def _looks_like_x_tweet(node: dict[str, object]) -> bool:
+    if _tweet_text(node) is None:
+        return False
+    return _string_value(node.get("id")) is not None
+
+
+def _tweet_text(tweet: dict[str, object]) -> str | None:
+    direct_text = _string_value(tweet.get("text")) or _string_value(
+        tweet.get("full_text")
+    )
+    if direct_text:
+        return direct_text
+
+    for path in (
+        ("legacy", "full_text"),
+        ("legacy", "text"),
+        ("note_tweet", "note_tweet_results", "result", "text"),
+    ):
+        value = _nested_string(tweet, *path)
+        if value:
+            return value
+    return None
+
+
+def _tweet_created_at(tweet: dict[str, object]) -> str | None:
+    return _string_value(tweet.get("created_at")) or _nested_string(
+        tweet, "legacy", "created_at"
+    )
+
+
+def _tweet_username(tweet: dict[str, object], users: dict[str, str]) -> str | None:
+    author_id = _string_value(tweet.get("author_id"))
+    if author_id and author_id in users:
+        return users[author_id]
+
+    for path in (
+        ("username",),
+        ("screen_name",),
+        ("user", "username"),
+        ("user", "screen_name"),
+        ("author", "username"),
+        ("author", "screen_name"),
+        ("legacy", "screen_name"),
+        ("core", "user_results", "result", "legacy", "screen_name"),
+        ("user_results", "result", "legacy", "screen_name"),
+    ):
+        value = _nested_string(tweet, *path)
+        if value:
+            return value
+    return None
+
+
+def _tweet_canonical_url(
+    tweet: dict[str, object],
+    tweet_id: str | None,
+    username: str | None,
+) -> str | None:
+    for key in ("url", "permalink"):
+        value = _string_value(tweet.get(key))
+        if value:
+            return value
+    if username and tweet_id:
+        return f"https://x.com/{username}/status/{tweet_id}"
+    return None
+
+
+def _nested_string(node: object, *path: str) -> str | None:
+    current = node
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return _string_value(current)
+
+
+def _string_value(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text or None
+    if isinstance(value, int):
+        return str(value)
+    return None
+
+
+def _coerce_x_tweets(value: list[object]) -> list[dict[str, object]]:
+    tweets: list[dict[str, object]] = []
+    for item in value:
+        if isinstance(item, dict) and _looks_like_x_tweet(item):
+            tweets.append(item)
+    return tweets

--- a/src/laminar/adapters.py
+++ b/src/laminar/adapters.py
@@ -7,6 +7,7 @@ from typing import Callable, Protocol
 from urllib.parse import parse_qsl, urlencode, urlparse
 from xml.etree import ElementTree
 
+from laminar.config import normalize_source_kind
 from laminar.fetch import fetch_text
 from laminar.models import NormalizedItem, SourceConfig
 from laminar.youtube import (
@@ -26,7 +27,7 @@ class Adapter(Protocol):
     ) -> list[NormalizedItem]: ...
 
 
-class BlogAdapter:
+class FeedAdapter:
     def scan(
         self,
         source: SourceConfig,
@@ -63,10 +64,10 @@ class BlogAdapter:
             items.append(
                 NormalizedItem(
                     source_id=source.id,
-                    item_type="blog",
+                    item_type="feed",
                     external_id=_find_text(entry, "./guid") or url,
                     canonical_url=url,
-                    title=_find_text(entry, "./title") or "(untitled blog post)",
+                    title=_find_text(entry, "./title") or "(untitled feed item)",
                     author=_find_text(entry, "./author") or channel_title,
                     published_at=published_at,
                     excerpt=description,
@@ -107,11 +108,11 @@ class BlogAdapter:
             items.append(
                 NormalizedItem(
                     source_id=source.id,
-                    item_type="blog",
+                    item_type="feed",
                     external_id=_find_text(entry, "./atom:id", ns) or url,
                     canonical_url=url,
                     title=_find_text(entry, "./atom:title", ns)
-                    or "(untitled blog post)",
+                    or "(untitled feed item)",
                     author=_find_text(entry, "./atom:author/atom:name", ns)
                     or feed_title,
                     published_at=published_at,
@@ -272,13 +273,14 @@ class XAdapter:
 
 
 def build_adapter(source: SourceConfig) -> Adapter:
-    if source.kind == "blog":
-        return BlogAdapter()
-    if source.kind == "youtube":
+    kind = normalize_source_kind(source.kind)
+    if kind == "feed":
+        return FeedAdapter()
+    if kind == "youtube":
         return YouTubeAdapter()
-    if source.kind == "x":
+    if kind == "x":
         return XAdapter()
-    raise ValueError(f"Unsupported source kind: {source.kind}")
+    raise ValueError(f"Unsupported source kind: {kind}")
 
 
 def _find_text(

--- a/src/laminar/adapters.py
+++ b/src/laminar/adapters.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import subprocess
 from datetime import datetime, timezone
-from typing import Protocol
+from typing import Callable, Protocol
 from urllib.parse import parse_qsl, urlencode, urlparse
 from xml.etree import ElementTree
 
@@ -22,6 +22,7 @@ class Adapter(Protocol):
         source: SourceConfig,
         *,
         since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]: ...
 
 
@@ -31,12 +32,13 @@ class BlogAdapter:
         source: SourceConfig,
         *,
         since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         xml_text = fetch_text(source.feed_url or "")
         root = ElementTree.fromstring(xml_text)
         if root.tag == "feed" or root.tag.endswith("}feed"):
-            return self._scan_atom(root, source, since=since)
-        return self._scan_rss(root, source, since=since)
+            return self._scan_atom(root, source, since=since, verbose=verbose)
+        return self._scan_rss(root, source, since=since, verbose=verbose)
 
     def _scan_rss(
         self,
@@ -44,12 +46,17 @@ class BlogAdapter:
         source: SourceConfig,
         *,
         since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         items: list[NormalizedItem] = []
         channel_title = _find_text(root, "./channel/title")
         for entry in root.findall("./channel/item"):
             published_at = _parse_dt(_find_text(entry, "./pubDate"))
             if since and published_at and published_at <= since:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: stopping rss scan at {_display_dt(published_at)} because it is at or before cutoff {_display_dt(since)}",
+                )
                 break
             url = _find_text(entry, "./link")
             description = _find_text(entry, "./description")
@@ -76,6 +83,7 @@ class BlogAdapter:
         source: SourceConfig,
         *,
         since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         ns = {"atom": "http://www.w3.org/2005/Atom"}
         items: list[NormalizedItem] = []
@@ -86,6 +94,10 @@ class BlogAdapter:
                 or _find_text(entry, "./atom:updated", ns)
             )
             if since and published_at and published_at <= since:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: stopping atom scan at {_display_dt(published_at)} because it is at or before cutoff {_display_dt(since)}",
+                )
                 break
             url = _find_text(entry, "./atom:link[@rel='alternate']", ns, attr="href")
             if url is None:
@@ -118,6 +130,7 @@ class YouTubeAdapter:
         source: SourceConfig,
         *,
         since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         xml_text = fetch_text(source.feed_url or "")
         root = ElementTree.fromstring(xml_text)
@@ -130,6 +143,10 @@ class YouTubeAdapter:
         for entry in root.findall("./atom:entry", ns):
             published_at = _parse_dt(_find_text(entry, "./atom:published", ns))
             if since and published_at and published_at <= since:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: stopping youtube scan at {_display_dt(published_at)} because it is at or before cutoff {_display_dt(since)}",
+                )
                 break
             video_url = _find_text(
                 entry, "./atom:link[@rel='alternate']", ns, attr="href"
@@ -163,8 +180,16 @@ class YouTubeAdapter:
                         for segment in transcript.segments
                     ]
                     transcript_status = "available"
+                    _verbose_log(
+                        verbose,
+                        f"{source.id}: transcript available for {video_id} in {transcript_language or 'unknown language'} via {transcript_source or 'unknown source'}",
+                    )
                 except TranscriptUnavailable:
                     transcript_status = "missing"
+                    _verbose_log(
+                        verbose,
+                        f"{source.id}: transcript missing for {video_id}",
+                    )
 
             items.append(
                 NormalizedItem(
@@ -199,14 +224,19 @@ class XAdapter:
         source: SourceConfig,
         *,
         since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
-        payload = _run_x_command(source)
+        payload = _run_x_command(source, verbose=verbose)
         data = json.loads(payload)
         tweets = _extract_x_tweets(data)
         if tweets is None:
             raise ValueError(
                 f"Source {source.id}: x payload must contain tweet-like objects"
             )
+        _verbose_log(
+            verbose,
+            f"{source.id}: x payload yielded {len(tweets)} candidate posts before cutoff filtering",
+        )
 
         users = _extract_x_users(data)
 
@@ -218,6 +248,10 @@ class XAdapter:
             text = _tweet_text(tweet)
             published_at = _parse_dt(_tweet_created_at(tweet))
             if since and published_at and published_at <= since:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: skipping x post {tweet_id or '(unknown id)'} from {_display_dt(published_at)} because it is at or before cutoff {_display_dt(since)}",
+                )
                 continue
             items.append(
                 NormalizedItem(
@@ -280,7 +314,11 @@ def _parse_dt(value: str | None) -> datetime | None:
     return None
 
 
-def _run_x_command(source: SourceConfig) -> str:
+def _run_x_command(
+    source: SourceConfig,
+    *,
+    verbose: Callable[[str], None] | None = None,
+) -> str:
     command = source.command[:]
     if not command:
         if source.feed_url:
@@ -290,6 +328,7 @@ def _run_x_command(source: SourceConfig) -> str:
             if not isinstance(api_url, str) or not api_url:
                 raise ValueError(f"Source {source.id}: missing x command target")
             command = ["xurl", api_url]
+    _verbose_log(verbose, f"{source.id}: running x command {' '.join(command)}")
 
     result = subprocess.run(
         command,
@@ -455,3 +494,17 @@ def _coerce_x_tweets(value: list[object]) -> list[dict[str, object]]:
         if isinstance(item, dict) and _looks_like_x_tweet(item):
             tweets.append(item)
     return tweets
+
+
+def _verbose_log(
+    verbose: Callable[[str], None] | None,
+    message: str,
+) -> None:
+    if verbose is not None:
+        verbose(message)
+
+
+def _display_dt(value: datetime | None) -> str:
+    if value is None:
+        return "(unknown time)"
+    return value.isoformat()

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -80,6 +80,15 @@ def build_parser() -> argparse.ArgumentParser:
         help="Extra metadata to persist with the source.",
     )
 
+    remove_source = source_subparsers.add_parser("remove")
+    remove_source.add_argument("source_id")
+    remove_source.add_argument(
+        "-r",
+        "--recursive",
+        action="store_true",
+        help="Also delete this source's items.",
+    )
+
     scan_parser = subparsers.add_parser("scan")
     scan_parser.set_defaults(command="scan")
     scan_parser.add_argument(
@@ -108,6 +117,9 @@ def build_parser() -> argparse.ArgumentParser:
 
     items_show = items_subparsers.add_parser("show")
     items_show.add_argument("item_id")
+
+    items_remove = items_subparsers.add_parser("remove")
+    items_remove.add_argument("item_id")
 
     search_parser = subparsers.add_parser("search")
     search_parser.set_defaults(command="search")
@@ -142,6 +154,25 @@ def _run_source(args: argparse.Namespace) -> int:
         validate_source(source)
         repo.upsert_source(source)
         _console().print(f"Saved source {source.id} in {runtime.database_path}")
+        return 0
+    if args.source_command == "remove":
+        try:
+            removed_items = repo.remove_source(
+                args.source_id,
+                recursive=args.recursive,
+            )
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
+        if removed_items is None:
+            print(f"Source {args.source_id} not found", file=sys.stderr)
+            return 1
+        if args.recursive:
+            _console().print(
+                f"Removed source {args.source_id} and deleted {removed_items} items from {runtime.database_path}"
+            )
+        else:
+            _console().print(f"Removed source {args.source_id} from {runtime.database_path}")
         return 0
 
     sources = repo.list_sources()
@@ -260,44 +291,14 @@ def _run_items(args: argparse.Namespace) -> int:
         _console().print(table)
         return 0
 
-    item = repo.get_item(args.item_id)
+    item = _resolve_item(repo, args.item_id)
     if item is None:
-        prefix_matches = repo.find_items_by_id_prefix(args.item_id)
-        if len(prefix_matches) == 1:
-            item = prefix_matches[0]
-        elif len(prefix_matches) > 1:
-            print(
-                f"Item ID prefix {args.item_id!r} is ambiguous. Try one of:",
-                file=sys.stderr,
-            )
-            for match in prefix_matches:
-                print(
-                    f"- {repo.shortest_unique_item_prefix(match.item_id)}\t{match.title}",
-                    file=sys.stderr,
-                )
-            return 1
-    if item is None:
-        matches = repo.find_items_by_title(args.item_id)
-        if len(matches) == 1:
-            item = matches[0]
-        elif len(matches) > 1:
-            print(
-                f"Multiple items found with title {args.item_id!r}; use the item ID instead.",
-                file=sys.stderr,
-            )
-            return 1
-    if item is None:
-        title_candidates = repo.lookup_titles_for_raw_title(args.item_id)
-        if len(title_candidates) > 1:
-            print(
-                f"Multiple items share the title {args.item_id!r}. Try one of:",
-                file=sys.stderr,
-            )
-            for candidate in title_candidates:
-                print(f"- {candidate}", file=sys.stderr)
-            return 1
-        print(f"Item {args.item_id} not found", file=sys.stderr)
         return 1
+
+    if args.items_command == "remove":
+        repo.remove_item(item.item_id)
+        _console().print(f"Removed item {item.item_id} from {runtime.database_path}")
+        return 0
 
     payload = {
         "item_id": item.item_id,
@@ -387,3 +388,45 @@ def _parse_metadata(pairs: list[str]) -> dict[str, object]:
             raise ConfigError(f"Metadata entries must be KEY=VALUE pairs: {pair}")
         metadata[key] = value
     return metadata
+
+
+def _resolve_item(repo: Repository, item_ref: str):
+    item = repo.get_item(item_ref)
+    if item is None:
+        prefix_matches = repo.find_items_by_id_prefix(item_ref)
+        if len(prefix_matches) == 1:
+            item = prefix_matches[0]
+        elif len(prefix_matches) > 1:
+            print(
+                f"Item ID prefix {item_ref!r} is ambiguous. Try one of:",
+                file=sys.stderr,
+            )
+            for match in prefix_matches:
+                print(
+                    f"- {repo.shortest_unique_item_prefix(match.item_id)}\t{match.title}",
+                    file=sys.stderr,
+                )
+            return None
+    if item is None:
+        matches = repo.find_items_by_title(item_ref)
+        if len(matches) == 1:
+            item = matches[0]
+        elif len(matches) > 1:
+            print(
+                f"Multiple items found with title {item_ref!r}; use the item ID instead.",
+                file=sys.stderr,
+            )
+            return None
+    if item is None:
+        title_candidates = repo.lookup_titles_for_raw_title(item_ref)
+        if len(title_candidates) > 1:
+            print(
+                f"Multiple items share the title {item_ref!r}. Try one of:",
+                file=sys.stderr,
+            )
+            for candidate in title_candidates:
+                print(f"- {candidate}", file=sys.stderr)
+            return None
+        print(f"Item {item_ref} not found", file=sys.stderr)
+        return None
+    return item

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -12,6 +12,7 @@ from laminar.config import (
     AppConfig,
     ConfigError,
     ensure_default_config,
+    normalize_source_kind,
     validate_source,
 )
 from laminar.models import SourceConfig
@@ -65,7 +66,7 @@ def build_parser() -> argparse.ArgumentParser:
     source_subparsers.add_parser("list")
 
     add_source = source_subparsers.add_parser("add")
-    add_source.add_argument("--kind", required=True, choices=["blog", "youtube", "x"])
+    add_source.add_argument("--kind", required=True, choices=["feed", "youtube", "x"])
     add_source.add_argument("--label", required=True)
     add_source.add_argument("--provider")
     add_source.add_argument("--feed-url")
@@ -114,7 +115,7 @@ def build_parser() -> argparse.ArgumentParser:
         "--source",
         dest="source_kinds",
         action="append",
-        choices=["blog", "youtube", "x"],
+        choices=["feed", "youtube", "x"],
         default=[],
         help="Limit scan to one or more source kinds.",
     )
@@ -226,13 +227,16 @@ def _run_scan(args: argparse.Namespace) -> int:
 
     sources = repo.list_sources()
     selected = {source_id for source_id in args.source_ids}
-    selected_kinds = set(args.source_kinds)
+    selected_kinds = {normalize_source_kind(kind) for kind in args.source_kinds}
     active_sources = [
         source
         for source in sources
         if source.enabled
         and (not selected or source.id in selected)
-        and (not selected_kinds or source.kind in selected_kinds)
+        and (
+            not selected_kinds
+            or normalize_source_kind(source.kind) in selected_kinds
+        )
     ]
 
     total_seen = 0
@@ -401,7 +405,7 @@ def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
     costs_money = args.costs_money or args.kind == "x"
     return SourceConfig(
         id=str(uuid4()),
-        kind=args.kind,
+        kind=normalize_source_kind(args.kind),
         label=args.label,
         enabled=not args.disable,
         costs_money=costs_money,

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -18,7 +18,6 @@ from laminar.config import (
 from laminar.models import SourceConfig
 from laminar.repository import Repository
 from rich.console import Console
-from rich.json import JSON
 from rich.table import Table
 
 
@@ -64,6 +63,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     source_subparsers.add_parser("validate")
     source_subparsers.add_parser("list")
+    show_source = source_subparsers.add_parser("show")
+    show_source.add_argument("source_id")
 
     add_source = source_subparsers.add_parser("add")
     add_source.add_argument("--kind", required=True, choices=["feed", "youtube", "x"])
@@ -141,6 +142,9 @@ def build_parser() -> argparse.ArgumentParser:
     search_parser.add_argument("query")
     search_parser.add_argument("--limit", type=int, default=20)
 
+    stats_parser = subparsers.add_parser("stats")
+    stats_parser.set_defaults(command="stats")
+
     return parser
 
 
@@ -158,6 +162,8 @@ def run(args: argparse.Namespace) -> int:
         return _run_items(args)
     if command == "search":
         return _run_search(args)
+    if command == "stats":
+        return _run_stats(args)
     raise ValueError(f"Unsupported command: {command}")
 
 
@@ -188,6 +194,38 @@ def _run_source(args: argparse.Namespace) -> int:
             )
         else:
             _console().print(f"Removed source {args.source_id} from {runtime.database_path}")
+        return 0
+    if args.source_command == "show":
+        source = repo.get_source(args.source_id)
+        if source is None:
+            print(f"Source {args.source_id} not found", file=sys.stderr)
+            return 1
+        source_stats = next(
+            (entry for entry in repo.stats().sources if entry.source_id == source.id),
+            None,
+        )
+        payload = {
+            "source_id": source.id,
+            "kind": source.kind,
+            "label": source.label,
+            "enabled": source.enabled,
+            "costs_money": source.costs_money,
+            "provider": source.provider,
+            "feed_url": source.feed_url,
+            "handle": source.handle,
+            "command": source.command,
+            "transcript_languages": source.transcript_languages,
+            "poll_interval_minutes": source.poll_interval_minutes,
+            "metadata": source.metadata,
+            "last_successful_scan_at": (
+                source.last_successful_scan_at.isoformat()
+                if source.last_successful_scan_at
+                else None
+            ),
+            "item_count": source_stats.item_count if source_stats else 0,
+            "logical_item_size_bytes": source_stats.size_bytes if source_stats else 0,
+        }
+        _print_json(payload)
         return 0
 
     sources = repo.list_sources()
@@ -358,7 +396,7 @@ def _run_items(args: argparse.Namespace) -> int:
         "content_text": item.content_text,
         "raw_payload": item.raw_payload,
     }
-    _console().print(JSON.from_data(payload, indent=2, sort_keys=True))
+    _print_json(payload)
     return 0
 
 
@@ -375,6 +413,73 @@ def _run_search(args: argparse.Namespace) -> int:
         table.add_row(item.item_id, item.item_type, item.source_id, item.title)
     _console().print(table)
     return 0
+
+
+def _run_stats(args: argparse.Namespace) -> int:
+    runtime = _load_runtime(args)
+    repo = Repository(runtime.database_path)
+    stats = repo.stats()
+    console = _console()
+
+    overview = Table(title="Overview")
+    overview.add_column("Metric", style="cyan")
+    overview.add_column("Value", justify="right", style="bold")
+    overview.add_row("Sources", str(stats.total_sources))
+    overview.add_row("Items", str(stats.total_items))
+    overview.add_row("Logical Item Size", _format_bytes(stats.total_size_bytes))
+    console.print(overview)
+
+    kind_table = Table(title="Sources by Kind")
+    kind_table.add_column("Kind", style="magenta")
+    kind_table.add_column("Sources", justify="right")
+    kind_table.add_column("Items", justify="right")
+    kind_table.add_column("Size", justify="right")
+    for kind in stats.kinds:
+        kind_table.add_row(
+            kind.kind,
+            str(kind.source_count),
+            str(kind.item_count),
+            _format_bytes(kind.size_bytes),
+        )
+    console.print(kind_table)
+
+    source_table = Table(title="Items by Source")
+    source_table.add_column("ID", style="cyan")
+    source_table.add_column("Label", style="bold")
+    source_table.add_column("Kind", style="magenta")
+    source_table.add_column("Status")
+    source_table.add_column("Cost")
+    source_table.add_column("Items", justify="right")
+    source_table.add_column("Size", justify="right")
+    for source in stats.sources:
+        source_table.add_row(
+            source.source_id,
+            source.label,
+            source.kind,
+            "enabled" if source.enabled else "disabled",
+            "paid" if source.costs_money else "free",
+            str(source.item_count),
+            _format_bytes(source.size_bytes),
+        )
+    console.print(source_table)
+    return 0
+
+
+def _format_bytes(size_bytes: int) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    size = float(size_bytes)
+    for unit in units:
+        if size < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(size)} {unit}"
+            return f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{size_bytes} B"
+
+
+def _print_json(payload: dict[str, object]) -> None:
+    sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True))
+    sys.stdout.write("\n")
 
 
 def main() -> None:

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -5,6 +5,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from urllib.parse import urlparse
 from uuid import uuid4
 
 from laminar.adapters import build_adapter
@@ -12,7 +13,6 @@ from laminar.config import (
     AppConfig,
     ConfigError,
     ensure_default_config,
-    normalize_source_kind,
     validate_source,
 )
 from laminar.models import SourceConfig
@@ -66,21 +66,44 @@ def build_parser() -> argparse.ArgumentParser:
     show_source = source_subparsers.add_parser("show")
     show_source.add_argument("source_id")
 
-    add_source = source_subparsers.add_parser("add")
-    add_source.add_argument("--kind", required=True, choices=["feed", "youtube", "x"])
-    add_source.add_argument("--label", required=True)
-    add_source.add_argument("--provider")
-    add_source.add_argument("--feed-url")
-    add_source.add_argument("--handle")
-    add_source.add_argument("--command", dest="source_exec", nargs="+")
-    add_source.add_argument("--transcript-language", action="append", default=[])
-    add_source.add_argument("--poll-interval-minutes", type=int)
-    add_source.add_argument(
-        "--costs-money",
-        action="store_true",
-        help="Mark this source as using a paid or metered integration.",
+    add_source = source_subparsers.add_parser(
+        "add",
+        help="Add a source by URL.",
+        description="Add a source by URL. Feed is the default type.",
     )
-    add_source.add_argument("--disable", action="store_true")
+    add_source.add_argument(
+        "url",
+        metavar="URL",
+        help="Source URL to ingest. For X, use a profile or list URL.",
+    )
+    add_source.add_argument(
+        "--type",
+        dest="kind",
+        default=None,
+        choices=["feed", "youtube", "x"],
+        help="Source type. When omitted, inferred from the URL: X URLs become x, YouTube URLs become youtube, otherwise feed.",
+    )
+    add_source.add_argument(
+        "--name",
+        required=True,
+        help="Human-friendly name shown in source listings and scan output.",
+    )
+    add_source.add_argument(
+        "--transcript-language",
+        action="append",
+        default=[],
+        help="Preferred transcript language for YouTube sources. Repeat to try more than one. Defaults to en.",
+    )
+    add_source.add_argument(
+        "--paid",
+        action="store_true",
+        help="Mark this source as using a paid or metered integration. X sources are paid by default.",
+    )
+    add_source.add_argument(
+        "--disable",
+        action="store_true",
+        help="Save the source in a disabled state so scans skip it.",
+    )
     add_source.add_argument(
         "--metadata",
         action="append",
@@ -210,12 +233,9 @@ def _run_source(args: argparse.Namespace) -> int:
             "label": source.label,
             "enabled": source.enabled,
             "costs_money": source.costs_money,
-            "provider": source.provider,
             "feed_url": source.feed_url,
             "handle": source.handle,
-            "command": source.command,
             "transcript_languages": source.transcript_languages,
-            "poll_interval_minutes": source.poll_interval_minutes,
             "metadata": source.metadata,
             "last_successful_scan_at": (
                 source.last_successful_scan_at.isoformat()
@@ -265,7 +285,7 @@ def _run_scan(args: argparse.Namespace) -> int:
 
     sources = repo.list_sources()
     selected = {source_id for source_id in args.source_ids}
-    selected_kinds = {normalize_source_kind(kind) for kind in args.source_kinds}
+    selected_kinds = set(args.source_kinds)
     active_sources = [
         source
         for source in sources
@@ -273,7 +293,7 @@ def _run_scan(args: argparse.Namespace) -> int:
         and (not selected or source.id in selected)
         and (
             not selected_kinds
-            or normalize_source_kind(source.kind) in selected_kinds
+            or source.kind in selected_kinds
         )
     ]
 
@@ -507,19 +527,22 @@ def _load_runtime(args: argparse.Namespace) -> AppConfig:
 
 
 def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
-    costs_money = args.costs_money or args.kind == "x"
+    feed_url = args.url
+    kind = _resolve_source_kind(feed_url, args.kind)
+    normalized_kind = kind
+    costs_money = args.paid or normalized_kind == "x"
+    transcript_languages = args.transcript_language
+    if normalized_kind == "youtube" and not transcript_languages:
+        transcript_languages = ["en"]
     return SourceConfig(
         id=str(uuid4()),
-        kind=normalize_source_kind(args.kind),
-        label=args.label,
+        kind=normalized_kind,
+        label=args.name,
         enabled=not args.disable,
         costs_money=costs_money,
-        provider=args.provider,
-        feed_url=args.feed_url,
-        handle=args.handle,
-        command=args.source_exec or [],
-        transcript_languages=args.transcript_language,
-        poll_interval_minutes=args.poll_interval_minutes,
+        feed_url=feed_url,
+        handle=_infer_x_handle(feed_url, normalized_kind),
+        transcript_languages=transcript_languages,
         metadata=_parse_metadata(args.metadata),
     )
 
@@ -536,6 +559,30 @@ def _parse_metadata(pairs: list[str]) -> dict[str, object]:
             raise ConfigError(f"Metadata entries must be KEY=VALUE pairs: {pair}")
         metadata[key] = value
     return metadata
+
+
+def _resolve_source_kind(url: str, explicit_kind: str | None) -> str:
+    if explicit_kind is not None:
+        return explicit_kind
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    if host.endswith("x.com"):
+        return "x"
+    if host.endswith("youtube.com") or host == "youtu.be":
+        return "youtube"
+    return "feed"
+
+
+def _infer_x_handle(url: str, kind: str) -> str | None:
+    if kind != "x":
+        return None
+    parsed = urlparse(url)
+    if not parsed.netloc.endswith("x.com"):
+        return None
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if not path_parts or "lists" in path_parts:
+        return None
+    return path_parts[0]
 
 
 def _resolve_item(repo: Repository, item_ref: str):

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -230,7 +230,7 @@ def _run_source(args: argparse.Namespace) -> int:
         payload = {
             "source_id": source.id,
             "kind": source.kind,
-            "label": source.label,
+            "name": source.name,
             "enabled": source.enabled,
             "costs_money": source.costs_money,
             "feed_url": source.feed_url,
@@ -260,14 +260,14 @@ def _run_source(args: argparse.Namespace) -> int:
     table.add_column("Kind", style="magenta")
     table.add_column("Status")
     table.add_column("Cost")
-    table.add_column("Label", style="bold")
+    table.add_column("Name", style="bold")
     for source in sources:
         table.add_row(
             source.id,
             source.kind,
             "enabled" if source.enabled else "disabled",
             "paid" if source.costs_money else "free",
-            source.label,
+            source.name,
         )
     _console().print(table)
     return 0
@@ -307,14 +307,14 @@ def _run_scan(args: argparse.Namespace) -> int:
     for source in active_sources:
         if source.costs_money and not args.include_paid:
             console.print(
-                f"Skipping {source.id} ({source.label}): paid source; rerun with --include-paid",
+                f"Skipping {source.id} ({source.name}): paid source; rerun with --include-paid",
                 style="grey50",
             )
             total_skipped += 1
             continue
         scan_started_at = datetime.now(timezone.utc)
         scan_id = repo.start_scan(source.id)
-        console.print(f"Scanning {source.id} ({source.label})")
+        console.print(f"Scanning {source.id} ({source.name})")
         if source.costs_money:
             console.print(
                 f"{source.id}: this source uses a paid or metered integration",
@@ -465,7 +465,7 @@ def _run_stats(args: argparse.Namespace) -> int:
 
     source_table = Table(title="Items by Source")
     source_table.add_column("ID", style="cyan")
-    source_table.add_column("Label", style="bold")
+    source_table.add_column("Name", style="bold")
     source_table.add_column("Kind", style="magenta")
     source_table.add_column("Status")
     source_table.add_column("Cost")
@@ -474,7 +474,7 @@ def _run_stats(args: argparse.Namespace) -> int:
     for source in stats.sources:
         source_table.add_row(
             source.source_id,
-            source.label,
+            source.name,
             source.kind,
             "enabled" if source.enabled else "disabled",
             "paid" if source.costs_money else "free",
@@ -537,7 +537,7 @@ def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
     return SourceConfig(
         id=str(uuid4()),
         kind=normalized_kind,
-        label=args.name,
+        name=args.name,
         enabled=not args.disable,
         costs_money=costs_money,
         feed_url=feed_url,

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -568,7 +568,7 @@ def _resolve_source_kind(url: str, explicit_kind: str | None) -> str:
     host = parsed.netloc.lower()
     if host.endswith("x.com"):
         return "x"
-    if host.endswith("youtube.com") or host == "youtu.be":
+    if host.endswith("youtube.com") and parsed.path == "/feeds/videos.xml":
         return "youtube"
     return "feed"
 

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -46,6 +46,13 @@ def build_parser() -> argparse.ArgumentParser:
         "--db",
         help="Path to SQLite database. Overrides database_path in config.yaml.",
     )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="global_verbose",
+        action="store_true",
+        help="Show detailed scan and ingest logging.",
+    )
 
     subparsers = parser.add_subparsers(dest="command", required=True)
 
@@ -92,9 +99,16 @@ def build_parser() -> argparse.ArgumentParser:
     scan_parser = subparsers.add_parser("scan")
     scan_parser.set_defaults(command="scan")
     scan_parser.add_argument(
+        "-i",
         "--include-paid",
         action="store_true",
         help="Include sources marked as paid or metered.",
+    )
+    scan_parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Show detailed scan and ingest logging.",
     )
     scan_parser.add_argument(
         "--source",
@@ -204,6 +218,12 @@ def _run_scan(args: argparse.Namespace) -> int:
     runtime = _load_runtime(args)
     repo = Repository(runtime.database_path)
     console = _console()
+    verbose = bool(getattr(args, "verbose", False) or getattr(args, "global_verbose", False))
+
+    def verbose_print(message: str) -> None:
+        if verbose:
+            console.print(message, style="dim", soft_wrap=True)
+
     sources = repo.list_sources()
     selected = {source_id for source_id in args.source_ids}
     selected_kinds = set(args.source_kinds)
@@ -219,6 +239,9 @@ def _run_scan(args: argparse.Namespace) -> int:
     total_new = 0
     total_failed = 0
     total_skipped = 0
+    verbose_print(
+        f"scan configuration: {len(active_sources)} active sources, include_paid={args.include_paid}, selected_kinds={sorted(selected_kinds) or ['all']}, selected_ids={sorted(selected) or ['all']}"
+    )
     for source in active_sources:
         if source.costs_money and not args.include_paid:
             console.print(
@@ -238,7 +261,20 @@ def _run_scan(args: argparse.Namespace) -> int:
         try:
             adapter = build_adapter(source)
             previous_scan_at = repo.last_successful_scan_at(source.id)
-            items = adapter.scan(source, since=previous_scan_at)
+            if previous_scan_at is None:
+                verbose_print(f"{source.id}: no previous successful scan; ingesting all available items")
+            else:
+                verbose_print(
+                    f"{source.id}: incremental cutoff is {previous_scan_at.isoformat()}"
+                )
+            items = adapter.scan(
+                source,
+                since=previous_scan_at,
+                verbose=verbose_print,
+            )
+            verbose_print(
+                f"{source.id}: adapter returned {len(items)} items after cutoff filtering"
+            )
             console.print(f"{source.id}: reachable", style="green")
             new_count = 0
             for item in items:
@@ -251,6 +287,9 @@ def _run_scan(args: argparse.Namespace) -> int:
                 scan_id, status="success", items_seen=len(items), items_new=new_count
             )
             repo.mark_source_scan_succeeded(source.id, scan_started_at)
+            verbose_print(
+                f"{source.id}: marked successful scan watermark at {scan_started_at.isoformat()}"
+            )
             total_seen += len(items)
             total_new += new_count
         except Exception as exc:

--- a/src/laminar/config.py
+++ b/src/laminar/config.py
@@ -22,6 +22,10 @@ class AppConfig:
     database_path: Path
 
 
+def normalize_source_kind(kind: str) -> str:
+    return "feed" if kind == "blog" else kind
+
+
 def ensure_default_config(path: str | Path) -> AppConfig:
     config_path = Path(path)
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -36,14 +40,15 @@ def ensure_default_config(path: str | Path) -> AppConfig:
 
 
 def validate_source(source: SourceConfig) -> None:
-    if source.kind not in {"blog", "youtube", "x"}:
+    kind = normalize_source_kind(source.kind)
+    if kind not in {"feed", "youtube", "x"}:
         raise ConfigError(f"Source {source.id}: unsupported kind {source.kind!r}")
 
-    if source.kind in {"blog", "youtube"} and not source.feed_url:
-        raise ConfigError(f"Source {source.id}: {source.kind} sources require feed_url")
+    if kind in {"feed", "youtube"} and not source.feed_url:
+        raise ConfigError(f"Source {source.id}: {kind} sources require feed_url")
 
     if (
-        source.kind == "x"
+        kind == "x"
         and not source.command
         and not source.feed_url
         and not source.metadata.get("api_url")

--- a/src/laminar/config.py
+++ b/src/laminar/config.py
@@ -42,8 +42,15 @@ def validate_source(source: SourceConfig) -> None:
     if source.kind in {"blog", "youtube"} and not source.feed_url:
         raise ConfigError(f"Source {source.id}: {source.kind} sources require feed_url")
 
-    if source.kind == "x" and not source.command and not source.metadata.get("api_url"):
-        raise ConfigError(f"Source {source.id}: x sources require command or api_url")
+    if (
+        source.kind == "x"
+        and not source.command
+        and not source.feed_url
+        and not source.metadata.get("api_url")
+    ):
+        raise ConfigError(
+            f"Source {source.id}: x sources require command, feed_url, or api_url"
+        )
 
 
 def _load_yaml_mapping(path: Path, *, label: str) -> dict[str, object]:

--- a/src/laminar/config.py
+++ b/src/laminar/config.py
@@ -21,11 +21,6 @@ class AppConfig:
     config_path: Path
     database_path: Path
 
-
-def normalize_source_kind(kind: str) -> str:
-    return "feed" if kind == "blog" else kind
-
-
 def ensure_default_config(path: str | Path) -> AppConfig:
     config_path = Path(path)
     config_path.parent.mkdir(parents=True, exist_ok=True)
@@ -40,22 +35,15 @@ def ensure_default_config(path: str | Path) -> AppConfig:
 
 
 def validate_source(source: SourceConfig) -> None:
-    kind = normalize_source_kind(source.kind)
+    kind = source.kind
     if kind not in {"feed", "youtube", "x"}:
         raise ConfigError(f"Source {source.id}: unsupported kind {source.kind!r}")
 
     if kind in {"feed", "youtube"} and not source.feed_url:
         raise ConfigError(f"Source {source.id}: {kind} sources require feed_url")
 
-    if (
-        kind == "x"
-        and not source.command
-        and not source.feed_url
-        and not source.metadata.get("api_url")
-    ):
-        raise ConfigError(
-            f"Source {source.id}: x sources require command, feed_url, or api_url"
-        )
+    if kind == "x" and not source.feed_url and not source.metadata.get("api_url"):
+        raise ConfigError(f"Source {source.id}: x sources require feed_url or api_url")
 
 
 def _load_yaml_mapping(path: Path, *, label: str) -> dict[str, object]:

--- a/src/laminar/models.py
+++ b/src/laminar/models.py
@@ -21,12 +21,9 @@ class SourceConfig:
     label: str
     enabled: bool = True
     costs_money: bool = False
-    provider: str | None = None
     feed_url: str | None = None
     handle: str | None = None
-    command: list[str] = field(default_factory=list)
     transcript_languages: list[str] = field(default_factory=list)
-    poll_interval_minutes: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
     last_successful_scan_at: datetime | None = None
 

--- a/src/laminar/models.py
+++ b/src/laminar/models.py
@@ -18,7 +18,7 @@ def new_uuid() -> str:
 class SourceConfig:
     id: str
     kind: str
-    label: str
+    name: str
     enabled: bool = True
     costs_money: bool = False
     feed_url: str | None = None
@@ -67,7 +67,7 @@ class StoredItem:
 @dataclass(slots=True)
 class SourceStats:
     source_id: str
-    label: str
+    name: str
     kind: str
     enabled: bool
     costs_money: bool

--- a/src/laminar/models.py
+++ b/src/laminar/models.py
@@ -28,6 +28,7 @@ class SourceConfig:
     transcript_languages: list[str] = field(default_factory=list)
     poll_interval_minutes: int | None = None
     metadata: dict[str, Any] = field(default_factory=dict)
+    last_successful_scan_at: datetime | None = None
 
 
 @dataclass(slots=True)
@@ -64,3 +65,31 @@ class StoredItem:
     content_language: str | None
     content_source: str | None
     raw_payload: dict[str, Any]
+
+
+@dataclass(slots=True)
+class SourceStats:
+    source_id: str
+    label: str
+    kind: str
+    enabled: bool
+    costs_money: bool
+    item_count: int
+    size_bytes: int
+
+
+@dataclass(slots=True)
+class SourceKindStats:
+    kind: str
+    source_count: int
+    item_count: int
+    size_bytes: int
+
+
+@dataclass(slots=True)
+class RepositoryStats:
+    total_sources: int
+    total_items: int
+    total_size_bytes: int
+    sources: list[SourceStats]
+    kinds: list[SourceKindStats]

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -6,7 +6,6 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
-from laminar.config import normalize_source_kind
 from laminar.models import (
     NormalizedItem,
     RepositoryStats,
@@ -24,12 +23,9 @@ CREATE TABLE IF NOT EXISTS sources (
     label TEXT NOT NULL,
     enabled INTEGER NOT NULL,
     costs_money INTEGER NOT NULL DEFAULT 0,
-    provider TEXT,
     feed_url TEXT,
     handle TEXT,
-    command_json TEXT NOT NULL DEFAULT '[]',
     transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-    poll_interval_minutes INTEGER,
     metadata_json TEXT NOT NULL,
     last_successful_scan_at TEXT,
     updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
@@ -87,6 +83,20 @@ CREATE INDEX IF NOT EXISTS idx_item_title_map_title
 ON item_title_map(title);
 """
 
+SOURCE_COLUMNS = [
+    "source_id",
+    "kind",
+    "label",
+    "enabled",
+    "costs_money",
+    "feed_url",
+    "handle",
+    "transcript_languages_json",
+    "metadata_json",
+    "last_successful_scan_at",
+    "updated_at",
+]
+
 
 class Repository:
     def __init__(self, db_path: str | Path) -> None:
@@ -111,21 +121,18 @@ class Repository:
             conn.execute(
                 """
                 INSERT INTO sources (
-                    source_id, kind, label, enabled, costs_money, provider, feed_url, handle,
-                    command_json, transcript_languages_json, poll_interval_minutes, metadata_json,
+                    source_id, kind, label, enabled, costs_money, feed_url, handle,
+                    transcript_languages_json, metadata_json,
                     last_successful_scan_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(source_id) DO UPDATE SET
                     kind = excluded.kind,
                     label = excluded.label,
                     enabled = excluded.enabled,
                     costs_money = excluded.costs_money,
-                    provider = excluded.provider,
                     feed_url = excluded.feed_url,
                     handle = excluded.handle,
-                    command_json = excluded.command_json,
                     transcript_languages_json = excluded.transcript_languages_json,
-                    poll_interval_minutes = excluded.poll_interval_minutes,
                     metadata_json = excluded.metadata_json,
                     updated_at = CURRENT_TIMESTAMP
                 """,
@@ -135,12 +142,9 @@ class Repository:
                     source.label,
                     int(source.enabled),
                     int(source.costs_money),
-                    source.provider,
                     source.feed_url,
                     source.handle,
-                    json.dumps(source.command),
                     json.dumps(source.transcript_languages),
-                    source.poll_interval_minutes,
                     json.dumps(source.metadata, sort_keys=True),
                     self.last_successful_scan_at(source.id),
                 ),
@@ -156,12 +160,9 @@ class Repository:
                     label,
                     enabled,
                     costs_money,
-                    provider,
                     feed_url,
                     handle,
-                    command_json,
                     transcript_languages_json,
-                    poll_interval_minutes,
                     metadata_json,
                     last_successful_scan_at
                 FROM sources
@@ -180,12 +181,9 @@ class Repository:
                     label,
                     enabled,
                     costs_money,
-                    provider,
                     feed_url,
                     handle,
-                    command_json,
                     transcript_languages_json,
-                    poll_interval_minutes,
                     metadata_json,
                     last_successful_scan_at
                 FROM sources
@@ -686,10 +684,9 @@ class Repository:
                 SourceStats(
                     source_id=str(row["source_id"]),
                     label=str(row["label"]),
-                    kind=normalize_source_kind(str(row["kind"])),
+                    kind=str(row["kind"]),
                     enabled=bool(row["enabled"]),
-                    costs_money=bool(row["costs_money"])
-                    or normalize_source_kind(str(row["kind"])) == "x",
+                    costs_money=bool(row["costs_money"]),
                     item_count=int(row["item_count"]),
                     size_bytes=int(row["size_bytes"]),
                 )
@@ -697,7 +694,7 @@ class Repository:
             ],
             kinds=[
                 SourceKindStats(
-                    kind=normalize_source_kind(str(row["kind"])),
+                    kind=str(row["kind"]),
                     source_count=int(row["source_count"]),
                     item_count=int(row["item_count"]),
                     size_bytes=int(row["size_bytes"]),
@@ -761,12 +758,86 @@ class Repository:
         source_columns = {
             str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
         }
+
         if "costs_money" not in source_columns:
             conn.execute(
                 "ALTER TABLE sources ADD COLUMN costs_money INTEGER NOT NULL DEFAULT 0"
             )
         if "last_successful_scan_at" not in source_columns:
             conn.execute("ALTER TABLE sources ADD COLUMN last_successful_scan_at TEXT")
+        source_columns = {
+            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
+        }
+        if source_columns != set(SOURCE_COLUMNS) or Repository._sources_need_data_migration(
+            conn
+        ):
+            Repository._rebuild_sources_table(conn)
+
+    @staticmethod
+    def _rebuild_sources_table(conn: sqlite3.Connection) -> None:
+        existing_columns = {
+            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
+        }
+        conn.execute("ALTER TABLE sources RENAME TO sources_legacy")
+        conn.execute(
+            """
+            CREATE TABLE sources (
+                source_id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                label TEXT NOT NULL,
+                enabled INTEGER NOT NULL,
+                costs_money INTEGER NOT NULL DEFAULT 0,
+                feed_url TEXT,
+                handle TEXT,
+                transcript_languages_json TEXT NOT NULL DEFAULT '[]',
+                metadata_json TEXT NOT NULL,
+                last_successful_scan_at TEXT,
+                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.execute(
+            f"""
+            INSERT INTO sources ({", ".join(SOURCE_COLUMNS)})
+            SELECT
+                source_id,
+                CASE WHEN kind = 'blog' THEN 'feed' ELSE kind END,
+                label,
+                enabled,
+                CASE
+                    WHEN kind = 'x' THEN 1
+                    ELSE {Repository._source_column_expr(existing_columns, "costs_money", "0")}
+                END,
+                {Repository._source_column_expr(existing_columns, "feed_url", "NULL")},
+                {Repository._source_column_expr(existing_columns, "handle", "NULL")},
+                {Repository._source_column_expr(existing_columns, "transcript_languages_json", "'[]'")},
+                {Repository._source_column_expr(existing_columns, "metadata_json", "'{}'")},
+                {Repository._source_column_expr(existing_columns, "last_successful_scan_at", "NULL")},
+                {Repository._source_column_expr(existing_columns, "updated_at", "CURRENT_TIMESTAMP")}
+            FROM sources_legacy
+            """
+        )
+        conn.execute("DROP TABLE sources_legacy")
+
+    @staticmethod
+    def _source_column_expr(
+        existing_columns: set[str], column_name: str, fallback_sql: str
+    ) -> str:
+        if column_name in existing_columns:
+            return column_name
+        return fallback_sql
+
+    @staticmethod
+    def _sources_need_data_migration(conn: sqlite3.Connection) -> bool:
+        row = conn.execute(
+            """
+            SELECT 1
+            FROM sources
+            WHERE kind = 'blog' OR (kind = 'x' AND costs_money = 0)
+            LIMIT 1
+            """
+        ).fetchone()
+        return row is not None
 
 
 def _row_to_item(row: sqlite3.Row) -> StoredItem:
@@ -788,19 +859,16 @@ def _row_to_item(row: sqlite3.Row) -> StoredItem:
 
 
 def _row_to_source(row: sqlite3.Row) -> SourceConfig:
-    kind = normalize_source_kind(str(row["kind"]))
+    kind = str(row["kind"])
     return SourceConfig(
         id=row["source_id"],
         kind=kind,
         label=row["label"],
         enabled=bool(row["enabled"]),
-        costs_money=bool(row["costs_money"]) or kind == "x",
-        provider=row["provider"],
+        costs_money=bool(row["costs_money"]),
         feed_url=row["feed_url"],
         handle=row["handle"],
-        command=_json_list(row["command_json"]),
         transcript_languages=_json_list(row["transcript_languages_json"]),
-        poll_interval_minutes=row["poll_interval_minutes"],
         metadata=_json_object(row["metadata_json"]),
         last_successful_scan_at=_parse_dt(row["last_successful_scan_at"]),
     )

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -6,6 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 
+from laminar.config import normalize_source_kind
 from laminar.models import NormalizedItem, SourceConfig, StoredItem
 
 
@@ -575,7 +576,7 @@ def _row_to_item(row: sqlite3.Row) -> StoredItem:
 
 
 def _row_to_source(row: sqlite3.Row) -> SourceConfig:
-    kind = str(row["kind"])
+    kind = normalize_source_kind(str(row["kind"]))
     return SourceConfig(
         id=row["source_id"],
         kind=kind,

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -7,7 +7,14 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from laminar.config import normalize_source_kind
-from laminar.models import NormalizedItem, SourceConfig, StoredItem
+from laminar.models import (
+    NormalizedItem,
+    RepositoryStats,
+    SourceConfig,
+    SourceKindStats,
+    SourceStats,
+    StoredItem,
+)
 
 
 SCHEMA = """
@@ -162,6 +169,31 @@ class Repository:
                 """
             ).fetchall()
         return [_row_to_source(row) for row in rows]
+
+    def get_source(self, source_id: str) -> SourceConfig | None:
+        with self.connect() as conn:
+            row = conn.execute(
+                """
+                SELECT
+                    source_id,
+                    kind,
+                    label,
+                    enabled,
+                    costs_money,
+                    provider,
+                    feed_url,
+                    handle,
+                    command_json,
+                    transcript_languages_json,
+                    poll_interval_minutes,
+                    metadata_json,
+                    last_successful_scan_at
+                FROM sources
+                WHERE source_id = ?
+                """,
+                (source_id,),
+            ).fetchone()
+        return _row_to_source(row) if row else None
 
     def remove_source(self, source_id: str, *, recursive: bool = False) -> int | None:
         with self.connect() as conn:
@@ -494,6 +526,186 @@ class Repository:
             ).fetchall()
         return [_row_to_item(row) for row in rows]
 
+    def stats(self) -> RepositoryStats:
+        with self.connect() as conn:
+            totals = conn.execute(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM sources) AS total_sources,
+                    (SELECT COUNT(*) FROM items) AS total_items,
+                    (
+                        SELECT COALESCE(SUM(
+                            length(CAST(i.item_id AS BLOB)) +
+                            length(CAST(i.source_id AS BLOB)) +
+                            length(CAST(i.item_type AS BLOB)) +
+                            length(CAST(COALESCE(i.external_id, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.canonical_url, '') AS BLOB)) +
+                            length(CAST(i.title AS BLOB)) +
+                            length(CAST(COALESCE(i.author, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.published_at, '') AS BLOB)) +
+                            length(CAST(i.retrieved_at AS BLOB)) +
+                            length(CAST(COALESCE(i.excerpt, '') AS BLOB)) +
+                            length(CAST(i.content_status AS BLOB)) +
+                            length(CAST(COALESCE(i.content_language, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.content_source, '') AS BLOB)) +
+                            length(CAST(i.raw_payload_json AS BLOB)) +
+                            length(CAST(i.content_hash AS BLOB)) +
+                            length(CAST(COALESCE(c.content_text, '') AS BLOB))
+                        ), 0)
+                        FROM items i
+                        LEFT JOIN item_contents c ON c.item_id = i.item_id
+                    ) AS total_size_bytes
+                """
+            ).fetchone()
+            source_rows = conn.execute(
+                """
+                WITH source_item_stats AS (
+                    SELECT
+                        i.source_id,
+                        COUNT(i.item_id) AS item_count,
+                        COALESCE(SUM(
+                            length(CAST(i.item_id AS BLOB)) +
+                            length(CAST(i.source_id AS BLOB)) +
+                            length(CAST(i.item_type AS BLOB)) +
+                            length(CAST(COALESCE(i.external_id, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.canonical_url, '') AS BLOB)) +
+                            length(CAST(i.title AS BLOB)) +
+                            length(CAST(COALESCE(i.author, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.published_at, '') AS BLOB)) +
+                            length(CAST(i.retrieved_at AS BLOB)) +
+                            length(CAST(COALESCE(i.excerpt, '') AS BLOB)) +
+                            length(CAST(i.content_status AS BLOB)) +
+                            length(CAST(COALESCE(i.content_language, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.content_source, '') AS BLOB)) +
+                            length(CAST(i.raw_payload_json AS BLOB)) +
+                            length(CAST(i.content_hash AS BLOB)) +
+                            length(CAST(COALESCE(c.content_text, '') AS BLOB))
+                        ), 0) AS size_bytes
+                    FROM items i
+                    LEFT JOIN item_contents c ON c.item_id = i.item_id
+                    GROUP BY i.source_id
+                )
+                SELECT
+                    s.source_id,
+                    s.label,
+                    s.kind,
+                    s.enabled,
+                    s.costs_money,
+                    COALESCE(sis.item_count, 0) AS item_count,
+                    COALESCE(sis.size_bytes, 0) AS size_bytes
+                FROM sources s
+                LEFT JOIN source_item_stats sis ON sis.source_id = s.source_id
+                UNION ALL
+                SELECT
+                    sis.source_id,
+                    '[missing source]' AS label,
+                    'missing' AS kind,
+                    0 AS enabled,
+                    0 AS costs_money,
+                    sis.item_count,
+                    sis.size_bytes
+                FROM source_item_stats sis
+                LEFT JOIN sources s ON s.source_id = sis.source_id
+                WHERE s.source_id IS NULL
+                ORDER BY 6 DESC, 7 DESC, 1
+                """
+            ).fetchall()
+            kind_rows = conn.execute(
+                """
+                WITH source_rollups AS (
+                    SELECT
+                        s.source_id,
+                        s.kind,
+                        COUNT(i.item_id) AS item_count,
+                        COALESCE(SUM(
+                            length(CAST(i.item_id AS BLOB)) +
+                            length(CAST(i.source_id AS BLOB)) +
+                            length(CAST(i.item_type AS BLOB)) +
+                            length(CAST(COALESCE(i.external_id, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.canonical_url, '') AS BLOB)) +
+                            length(CAST(i.title AS BLOB)) +
+                            length(CAST(COALESCE(i.author, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.published_at, '') AS BLOB)) +
+                            length(CAST(i.retrieved_at AS BLOB)) +
+                            length(CAST(COALESCE(i.excerpt, '') AS BLOB)) +
+                            length(CAST(i.content_status AS BLOB)) +
+                            length(CAST(COALESCE(i.content_language, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.content_source, '') AS BLOB)) +
+                            length(CAST(i.raw_payload_json AS BLOB)) +
+                            length(CAST(i.content_hash AS BLOB)) +
+                            length(CAST(COALESCE(c.content_text, '') AS BLOB))
+                        ), 0) AS size_bytes
+                    FROM sources s
+                    LEFT JOIN items i ON i.source_id = s.source_id
+                    LEFT JOIN item_contents c ON c.item_id = i.item_id
+                    GROUP BY s.source_id, s.kind
+                    UNION ALL
+                    SELECT
+                        i.source_id,
+                        'missing' AS kind,
+                        COUNT(i.item_id) AS item_count,
+                        COALESCE(SUM(
+                            length(CAST(i.item_id AS BLOB)) +
+                            length(CAST(i.source_id AS BLOB)) +
+                            length(CAST(i.item_type AS BLOB)) +
+                            length(CAST(COALESCE(i.external_id, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.canonical_url, '') AS BLOB)) +
+                            length(CAST(i.title AS BLOB)) +
+                            length(CAST(COALESCE(i.author, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.published_at, '') AS BLOB)) +
+                            length(CAST(i.retrieved_at AS BLOB)) +
+                            length(CAST(COALESCE(i.excerpt, '') AS BLOB)) +
+                            length(CAST(i.content_status AS BLOB)) +
+                            length(CAST(COALESCE(i.content_language, '') AS BLOB)) +
+                            length(CAST(COALESCE(i.content_source, '') AS BLOB)) +
+                            length(CAST(i.raw_payload_json AS BLOB)) +
+                            length(CAST(i.content_hash AS BLOB)) +
+                            length(CAST(COALESCE(c.content_text, '') AS BLOB))
+                        ), 0) AS size_bytes
+                    FROM items i
+                    LEFT JOIN item_contents c ON c.item_id = i.item_id
+                    LEFT JOIN sources s ON s.source_id = i.source_id
+                    WHERE s.source_id IS NULL
+                    GROUP BY i.source_id
+                )
+                SELECT
+                    kind,
+                    COUNT(*) AS source_count,
+                    SUM(item_count) AS item_count,
+                    SUM(size_bytes) AS size_bytes
+                FROM source_rollups
+                GROUP BY kind
+                ORDER BY 2 DESC, 4 DESC, 1
+                """
+            ).fetchall()
+        return RepositoryStats(
+            total_sources=int(totals["total_sources"]),
+            total_items=int(totals["total_items"]),
+            total_size_bytes=int(totals["total_size_bytes"]),
+            sources=[
+                SourceStats(
+                    source_id=str(row["source_id"]),
+                    label=str(row["label"]),
+                    kind=normalize_source_kind(str(row["kind"])),
+                    enabled=bool(row["enabled"]),
+                    costs_money=bool(row["costs_money"])
+                    or normalize_source_kind(str(row["kind"])) == "x",
+                    item_count=int(row["item_count"]),
+                    size_bytes=int(row["size_bytes"]),
+                )
+                for row in source_rows
+            ],
+            kinds=[
+                SourceKindStats(
+                    kind=normalize_source_kind(str(row["kind"])),
+                    source_count=int(row["source_count"]),
+                    item_count=int(row["item_count"]),
+                    size_bytes=int(row["size_bytes"]),
+                )
+                for row in kind_rows
+            ],
+        )
+
     @staticmethod
     def _content_hash(item: NormalizedItem) -> str:
         parts = [
@@ -590,6 +802,7 @@ def _row_to_source(row: sqlite3.Row) -> SourceConfig:
         transcript_languages=_json_list(row["transcript_languages_json"]),
         poll_interval_minutes=row["poll_interval_minutes"],
         metadata=_json_object(row["metadata_json"]),
+        last_successful_scan_at=_parse_dt(row["last_successful_scan_at"]),
     )
 
 

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -162,6 +162,42 @@ class Repository:
             ).fetchall()
         return [_row_to_source(row) for row in rows]
 
+    def remove_source(self, source_id: str, *, recursive: bool = False) -> int | None:
+        with self.connect() as conn:
+            existing = conn.execute(
+                "SELECT 1 FROM sources WHERE source_id = ?",
+                (source_id,),
+            ).fetchone()
+            if existing is None:
+                return None
+
+            item_rows = conn.execute(
+                "SELECT item_id, title FROM items WHERE source_id = ?",
+                (source_id,),
+            ).fetchall()
+            if item_rows and not recursive:
+                raise ValueError(
+                    f"Source {source_id} still has {len(item_rows)} items; rerun with --recursive"
+                )
+
+            for row in item_rows:
+                conn.execute(
+                    "DELETE FROM item_contents WHERE item_id = ?",
+                    (str(row["item_id"]),),
+                )
+                conn.execute(
+                    "DELETE FROM item_title_map WHERE item_id = ?",
+                    (str(row["item_id"]),),
+                )
+            if item_rows:
+                conn.execute("DELETE FROM items WHERE source_id = ?", (source_id,))
+                for title in {str(row["title"]) for row in item_rows}:
+                    self._refresh_title_map_for_title(conn, title)
+
+            conn.execute("DELETE FROM scans WHERE source_id = ?", (source_id,))
+            conn.execute("DELETE FROM sources WHERE source_id = ?", (source_id,))
+            return len(item_rows)
+
     def last_successful_scan_at(self, source_id: str) -> datetime | None:
         with self.connect() as conn:
             row = conn.execute(
@@ -351,6 +387,22 @@ class Repository:
                 (item_id,),
             ).fetchone()
         return _row_to_item(row) if row else None
+
+    def remove_item(self, item_id: str) -> bool:
+        with self.connect() as conn:
+            row = conn.execute(
+                "SELECT title FROM items WHERE item_id = ?",
+                (item_id,),
+            ).fetchone()
+            if row is None:
+                return False
+
+            title = str(row["title"])
+            conn.execute("DELETE FROM item_contents WHERE item_id = ?", (item_id,))
+            conn.execute("DELETE FROM item_title_map WHERE item_id = ?", (item_id,))
+            conn.execute("DELETE FROM items WHERE item_id = ?", (item_id,))
+            self._refresh_title_map_for_title(conn, title)
+            return True
 
     def find_items_by_id_prefix(self, prefix: str, *, limit: int = 10) -> list[StoredItem]:
         with self.connect() as conn:

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -20,7 +20,7 @@ SCHEMA = """
 CREATE TABLE IF NOT EXISTS sources (
     source_id TEXT PRIMARY KEY,
     kind TEXT NOT NULL,
-    label TEXT NOT NULL,
+    name TEXT NOT NULL,
     enabled INTEGER NOT NULL,
     costs_money INTEGER NOT NULL DEFAULT 0,
     feed_url TEXT,
@@ -83,28 +83,12 @@ CREATE INDEX IF NOT EXISTS idx_item_title_map_title
 ON item_title_map(title);
 """
 
-SOURCE_COLUMNS = [
-    "source_id",
-    "kind",
-    "label",
-    "enabled",
-    "costs_money",
-    "feed_url",
-    "handle",
-    "transcript_languages_json",
-    "metadata_json",
-    "last_successful_scan_at",
-    "updated_at",
-]
-
-
 class Repository:
     def __init__(self, db_path: str | Path) -> None:
         self.db_path = Path(db_path)
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
         with self.connect() as conn:
             conn.executescript(SCHEMA)
-            self._ensure_schema_columns(conn)
 
     @contextmanager
     def connect(self):
@@ -121,13 +105,13 @@ class Repository:
             conn.execute(
                 """
                 INSERT INTO sources (
-                    source_id, kind, label, enabled, costs_money, feed_url, handle,
+                    source_id, kind, name, enabled, costs_money, feed_url, handle,
                     transcript_languages_json, metadata_json,
                     last_successful_scan_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(source_id) DO UPDATE SET
                     kind = excluded.kind,
-                    label = excluded.label,
+                    name = excluded.name,
                     enabled = excluded.enabled,
                     costs_money = excluded.costs_money,
                     feed_url = excluded.feed_url,
@@ -139,7 +123,7 @@ class Repository:
                 (
                     source.id,
                     source.kind,
-                    source.label,
+                    source.name,
                     int(source.enabled),
                     int(source.costs_money),
                     source.feed_url,
@@ -157,7 +141,7 @@ class Repository:
                 SELECT
                     source_id,
                     kind,
-                    label,
+                    name,
                     enabled,
                     costs_money,
                     feed_url,
@@ -178,7 +162,7 @@ class Repository:
                 SELECT
                     source_id,
                     kind,
-                    label,
+                    name,
                     enabled,
                     costs_money,
                     feed_url,
@@ -585,7 +569,7 @@ class Repository:
                 )
                 SELECT
                     s.source_id,
-                    s.label,
+                    s.name,
                     s.kind,
                     s.enabled,
                     s.costs_money,
@@ -596,7 +580,7 @@ class Repository:
                 UNION ALL
                 SELECT
                     sis.source_id,
-                    '[missing source]' AS label,
+                    '[missing source]' AS name,
                     'missing' AS kind,
                     0 AS enabled,
                     0 AS costs_money,
@@ -683,7 +667,7 @@ class Repository:
             sources=[
                 SourceStats(
                     source_id=str(row["source_id"]),
-                    label=str(row["label"]),
+                    name=str(row["name"]),
                     kind=str(row["kind"]),
                     enabled=bool(row["enabled"]),
                     costs_money=bool(row["costs_money"]),
@@ -719,7 +703,7 @@ class Repository:
     def _refresh_title_map_for_title(conn: sqlite3.Connection, title: str) -> None:
         rows = conn.execute(
             """
-            SELECT i.item_id, i.title, COALESCE(s.label, i.source_id) AS source_name
+            SELECT i.item_id, i.title, COALESCE(s.name, i.source_id) AS source_name
             FROM items i
             LEFT JOIN sources s ON s.source_id = i.source_id
             WHERE i.title = ?
@@ -752,94 +736,6 @@ class Repository:
                 (lookup_name, str(row["item_id"])),
             )
 
-
-    @staticmethod
-    def _ensure_schema_columns(conn: sqlite3.Connection) -> None:
-        source_columns = {
-            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
-        }
-
-        if "costs_money" not in source_columns:
-            conn.execute(
-                "ALTER TABLE sources ADD COLUMN costs_money INTEGER NOT NULL DEFAULT 0"
-            )
-        if "last_successful_scan_at" not in source_columns:
-            conn.execute("ALTER TABLE sources ADD COLUMN last_successful_scan_at TEXT")
-        source_columns = {
-            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
-        }
-        if source_columns != set(SOURCE_COLUMNS) or Repository._sources_need_data_migration(
-            conn
-        ):
-            Repository._rebuild_sources_table(conn)
-
-    @staticmethod
-    def _rebuild_sources_table(conn: sqlite3.Connection) -> None:
-        existing_columns = {
-            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
-        }
-        conn.execute("ALTER TABLE sources RENAME TO sources_legacy")
-        conn.execute(
-            """
-            CREATE TABLE sources (
-                source_id TEXT PRIMARY KEY,
-                kind TEXT NOT NULL,
-                label TEXT NOT NULL,
-                enabled INTEGER NOT NULL,
-                costs_money INTEGER NOT NULL DEFAULT 0,
-                feed_url TEXT,
-                handle TEXT,
-                transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-                metadata_json TEXT NOT NULL,
-                last_successful_scan_at TEXT,
-                updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-            )
-            """
-        )
-        conn.execute(
-            f"""
-            INSERT INTO sources ({", ".join(SOURCE_COLUMNS)})
-            SELECT
-                source_id,
-                CASE WHEN kind = 'blog' THEN 'feed' ELSE kind END,
-                label,
-                enabled,
-                CASE
-                    WHEN kind = 'x' THEN 1
-                    ELSE {Repository._source_column_expr(existing_columns, "costs_money", "0")}
-                END,
-                {Repository._source_column_expr(existing_columns, "feed_url", "NULL")},
-                {Repository._source_column_expr(existing_columns, "handle", "NULL")},
-                {Repository._source_column_expr(existing_columns, "transcript_languages_json", "'[]'")},
-                {Repository._source_column_expr(existing_columns, "metadata_json", "'{}'")},
-                {Repository._source_column_expr(existing_columns, "last_successful_scan_at", "NULL")},
-                {Repository._source_column_expr(existing_columns, "updated_at", "CURRENT_TIMESTAMP")}
-            FROM sources_legacy
-            """
-        )
-        conn.execute("DROP TABLE sources_legacy")
-
-    @staticmethod
-    def _source_column_expr(
-        existing_columns: set[str], column_name: str, fallback_sql: str
-    ) -> str:
-        if column_name in existing_columns:
-            return column_name
-        return fallback_sql
-
-    @staticmethod
-    def _sources_need_data_migration(conn: sqlite3.Connection) -> bool:
-        row = conn.execute(
-            """
-            SELECT 1
-            FROM sources
-            WHERE kind = 'blog' OR (kind = 'x' AND costs_money = 0)
-            LIMIT 1
-            """
-        ).fetchone()
-        return row is not None
-
-
 def _row_to_item(row: sqlite3.Row) -> StoredItem:
     return StoredItem(
         item_id=str(row["item_id"]),
@@ -863,7 +759,7 @@ def _row_to_source(row: sqlite3.Row) -> SourceConfig:
     return SourceConfig(
         id=row["source_id"],
         kind=kind,
-        label=row["label"],
+        name=row["name"],
         enabled=bool(row["enabled"]),
         costs_money=bool(row["costs_money"]),
         feed_url=row["feed_url"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -100,8 +100,16 @@ def test_scan_and_query(tmp_path: Path) -> None:
         )
 
     adapters.fetch_transcript = fake_fetch_transcript
-    with redirect_stdout(io.StringIO()):
-        for args_list in (
+    original_run = adapters.subprocess.run
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["xurl", "https://x.com/example"]
+        return subprocess.CompletedProcess(command, 0, stdout=x_payload.read_text(), stderr="")
+
+    adapters.subprocess.run = fake_run
+    try:
+        with redirect_stdout(io.StringIO()):
+            for args_list in (
             [
                 "--config",
                 str(config_path),
@@ -109,11 +117,8 @@ def test_scan_and_query(tmp_path: Path) -> None:
                 str(db_path),
                 "source",
                 "add",
-                "--kind",
-                "feed",
-                "--label",
+                "--name",
                 "Example Feed",
-                "--feed-url",
                 blog_feed.as_uri(),
             ],
             [
@@ -123,11 +128,10 @@ def test_scan_and_query(tmp_path: Path) -> None:
                 str(db_path),
                 "source",
                 "add",
-                "--kind",
+                "--type",
                 "youtube",
-                "--label",
+                "--name",
                 "Example Channel",
-                "--feed-url",
                 yt_feed.as_uri(),
                 "--transcript-language",
                 "en",
@@ -139,16 +143,12 @@ def test_scan_and_query(tmp_path: Path) -> None:
                 str(db_path),
                 "source",
                 "add",
-                "--kind",
+                "--type",
                 "x",
-                "--label",
+                "--name",
                 "Example X",
-                "--costs-money",
-                "--handle",
-                "example",
-                "--command",
-                "cat",
-                str(x_payload),
+                "--paid",
+                "https://x.com/example",
             ],
             [
                 "--config",
@@ -159,10 +159,12 @@ def test_scan_and_query(tmp_path: Path) -> None:
                 "validate",
             ],
             ["--config", str(config_path), "--db", str(db_path), "scan"],
-        ):
-            args = parser.parse_args(args_list)
-            assert run(args) == 0
-    adapters.fetch_transcript = original_fetch
+            ):
+                args = parser.parse_args(args_list)
+                assert run(args) == 0
+    finally:
+        adapters.fetch_transcript = original_fetch
+        adapters.subprocess.run = original_run
 
     list_buffer = io.StringIO()
     with redirect_stdout(list_buffer):
@@ -284,7 +286,7 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
         label="Healthy Feed",
         costs_money=True,
         handle="healthy",
-        command=["unused"],
+        feed_url="https://x.com/healthy",
     )
     repo.upsert_source(failing)
     repo.upsert_source(healthy)
@@ -388,7 +390,7 @@ def test_scan_skips_paid_sources_without_include_paid(tmp_path: Path) -> None:
             label="Paid X",
             costs_money=True,
             handle="example",
-            command=["unused"],
+            feed_url="https://x.com/example",
         )
     )
 
@@ -506,35 +508,31 @@ def test_scan_uses_last_successful_scan_time_for_incremental_blog_and_youtube(
         with redirect_stdout(io.StringIO()):
             for args_list in (
                 [
-                    "--config",
-                    str(config_path),
-                    "--db",
-                    str(db_path),
-                    "source",
-                    "add",
-                    "--kind",
-                    "feed",
-                    "--label",
-                    "Example Feed",
-                    "--feed-url",
-                    blog_feed.as_uri(),
-                ],
-                [
-                    "--config",
-                    str(config_path),
-                    "--db",
-                    str(db_path),
-                    "source",
-                    "add",
-                    "--kind",
-                    "youtube",
-                    "--label",
-                    "Example Channel",
-                    "--feed-url",
-                    yt_feed.as_uri(),
-                    "--transcript-language",
-                    "en",
-                ],
+                "--config",
+                str(config_path),
+                "--db",
+                str(db_path),
+                "source",
+                "add",
+                "--name",
+                "Example Feed",
+                blog_feed.as_uri(),
+            ],
+            [
+                "--config",
+                str(config_path),
+                "--db",
+                str(db_path),
+                "source",
+                "add",
+                "--type",
+                "youtube",
+                "--name",
+                "Example Channel",
+                yt_feed.as_uri(),
+                "--transcript-language",
+                "en",
+            ],
             ):
                 args = parser.parse_args(args_list)
                 assert run(args) == 0
@@ -599,16 +597,12 @@ def test_scan_filters_x_items_using_last_successful_scan_time(tmp_path: Path) ->
                 str(db_path),
                 "source",
                 "add",
-                "--kind",
+                "--type",
                 "x",
-                "--label",
+                "--name",
                 "Example X",
-                "--costs-money",
-                "--handle",
-                "example",
-                "--command",
-                "cat",
-                str(x_payload),
+                "--paid",
+                "https://x.com/example",
             ]
         )
         assert run(args) == 0
@@ -618,12 +612,22 @@ def test_scan_filters_x_items_using_last_successful_scan_time(tmp_path: Path) ->
     cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
     repo.mark_source_scan_succeeded(source_id, cutoff)
 
-    scan_buffer = io.StringIO()
-    with redirect_stdout(scan_buffer):
-        args = parser.parse_args(
-            ["--config", str(config_path), "--db", str(db_path), "scan", "--include-paid"]
-        )
-        assert run(args) == 0
+    original_run = adapters.subprocess.run
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["xurl", "https://x.com/example"]
+        return subprocess.CompletedProcess(command, 0, stdout=x_payload.read_text(), stderr="")
+
+    adapters.subprocess.run = fake_run
+    try:
+        scan_buffer = io.StringIO()
+        with redirect_stdout(scan_buffer):
+            args = parser.parse_args(
+                ["--config", str(config_path), "--db", str(db_path), "scan", "--include-paid"]
+            )
+            assert run(args) == 0
+    finally:
+        adapters.subprocess.run = original_run
 
     output = scan_buffer.getvalue()
     assert f"{source_id}: new new post" in output
@@ -693,11 +697,8 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
                 str(db_path),
                 "source",
                 "add",
-                "--kind",
-                "feed",
-                "--label",
+                "--name",
                 "Example Feed",
-                "--feed-url",
                 blog_feed.as_uri(),
             ],
             [
@@ -707,16 +708,12 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
                 str(db_path),
                 "source",
                 "add",
-                "--kind",
+                "--type",
                 "x",
-                "--label",
+                "--name",
                 "Example X",
-                "--costs-money",
-                "--handle",
-                "example",
-                "--command",
-                "cat",
-                str(x_payload),
+                "--paid",
+                "https://x.com/example",
             ],
         ):
             args = parser.parse_args(args_list)
@@ -728,20 +725,30 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
     repo.mark_source_scan_succeeded(sources_by_label["Example Feed"], cutoff)
     repo.mark_source_scan_succeeded(sources_by_label["Example X"], cutoff)
 
-    scan_buffer = io.StringIO()
-    with redirect_stdout(scan_buffer):
-        args = parser.parse_args(
-            [
-                "--config",
-                str(config_path),
-                "--db",
-                str(db_path),
-                "--verbose",
-                "scan",
-                "--include-paid",
-            ]
-        )
-        assert run(args) == 0
+    original_run = adapters.subprocess.run
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["xurl", "https://x.com/example"]
+        return subprocess.CompletedProcess(command, 0, stdout=x_payload.read_text(), stderr="")
+
+    adapters.subprocess.run = fake_run
+    try:
+        scan_buffer = io.StringIO()
+        with redirect_stdout(scan_buffer):
+            args = parser.parse_args(
+                [
+                    "--config",
+                    str(config_path),
+                    "--db",
+                    str(db_path),
+                    "--verbose",
+                    "scan",
+                    "--include-paid",
+                ]
+            )
+            assert run(args) == 0
+    finally:
+        adapters.subprocess.run = original_run
 
     output = scan_buffer.getvalue()
     blog_source_id = sources_by_label["Example Feed"]
@@ -846,7 +853,7 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
         label="Example X",
         costs_money=True,
         handle="example",
-        command=["unused"],
+        feed_url="https://x.com/example",
     )
     repo.upsert_source(blog_source)
     repo.upsert_source(youtube_source)
@@ -1031,11 +1038,8 @@ def test_source_list_reads_sources_from_database(tmp_path: Path) -> None:
             str(db_path),
             "source",
             "add",
-            "--kind",
-            "feed",
-            "--label",
+            "--name",
             "Example Feed",
-            "--feed-url",
             "file:///tmp/feed.xml",
         ]
     )
@@ -1064,16 +1068,12 @@ def test_source_list_shows_paid_sources(tmp_path: Path) -> None:
             str(db_path),
             "source",
             "add",
-            "--kind",
+            "--type",
             "x",
-            "--label",
+            "--name",
             "Paid X",
-            "--costs-money",
-            "--handle",
-            "example",
-            "--command",
-            "echo",
-            "[]",
+            "--paid",
+            "https://x.com/example",
         ]
     )
     assert run(add_args) == 0
@@ -1097,15 +1097,9 @@ def test_x_sources_default_to_paid(tmp_path: Path) -> None:
             str(db_path),
             "source",
             "add",
-            "--kind",
-            "x",
-            "--label",
+            "--name",
             "Default Paid X",
-            "--handle",
-            "example",
-            "--command",
-            "echo",
-            "[]",
+            "https://x.com/example",
         ]
     )
     assert run(add_args) == 0
@@ -1116,6 +1110,101 @@ def test_x_sources_default_to_paid(tmp_path: Path) -> None:
     assert len(sources) == 1
     assert sources[0].kind == "x"
     assert sources[0].costs_money is True
+
+
+def test_x_profile_urls_infer_handle(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--name",
+            "Example X",
+            "https://x.com/example",
+        ]
+    )
+    assert run(add_args) == 0
+
+    sources = Repository(db_path).list_sources()
+    assert len(sources) == 1
+    assert sources[0].handle == "example"
+
+
+def test_youtube_urls_infer_youtube_kind(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--name",
+            "Example Channel",
+            "https://www.youtube.com/feeds/videos.xml?channel_id=abc123",
+        ]
+    )
+    assert run(add_args) == 0
+
+    sources = Repository(db_path).list_sources()
+    assert len(sources) == 1
+    assert sources[0].kind == "youtube"
+    assert sources[0].transcript_languages == ["en"]
+
+
+def test_youtube_sources_default_transcript_language_to_english(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--type",
+            "youtube",
+            "--name",
+            "Example Channel",
+            "https://www.youtube.com/feeds/videos.xml?channel_id=abc123",
+        ]
+    )
+    assert run(add_args) == 0
+
+    sources = Repository(db_path).list_sources()
+    assert len(sources) == 1
+    assert sources[0].transcript_languages == ["en"]
+
+
+def test_explicit_type_overrides_url_inference(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--type",
+            "feed",
+            "--name",
+            "Forced Feed",
+            "https://x.com/example",
+        ]
+    )
+    assert run(add_args) == 0
+
+    sources = Repository(db_path).list_sources()
+    assert len(sources) == 1
+    assert sources[0].kind == "feed"
+    assert sources[0].costs_money is False
+    assert sources[0].handle is None
 
 
 def test_x_list_sources_use_xurl_and_store_list_contents(tmp_path: Path) -> None:
@@ -1133,11 +1222,10 @@ def test_x_list_sources_use_xurl_and_store_list_contents(tmp_path: Path) -> None
             str(db_path),
             "source",
             "add",
-            "--kind",
+            "--type",
             "x",
-            "--label",
+            "--name",
             "AI List",
-            "--feed-url",
             list_url,
         ]
     )
@@ -1190,6 +1278,32 @@ def test_x_list_browser_url_is_translated_to_list_tweets_api_target() -> None:
         "/2/lists/9876543210/tweets"
         "?expansions=author_id&max_results=100&tweet.fields=created_at&user.fields=username"
     )
+
+
+def test_source_add_help_uses_url_type_and_paid_flags(capsys) -> None:
+    parser = build_parser()
+
+    try:
+        parser.parse_args(["source", "add", "--help"])
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    captured = capsys.readouterr()
+    help_text = captured.out
+    assert "URL" in help_text
+    assert "--name" in help_text
+    assert "--type" in help_text
+    assert "--paid" in help_text
+    assert "inferred from the URL" in help_text
+    assert "Defaults to en." in help_text
+    assert "{feed,youtube,x}" in help_text
+    assert "blog" not in help_text
+    assert "--label" not in help_text
+    assert "--kind" not in help_text
+    assert "--feed-url" not in help_text
+    assert "--command" not in help_text
+    assert "--costs-money" not in help_text
+    assert "--handle" not in help_text
 
 
 def test_source_remove_deletes_source_without_items(tmp_path: Path) -> None:
@@ -1294,11 +1408,8 @@ def test_scan_and_query_atom_blog_feed(tmp_path: Path) -> None:
             str(db_path),
             "source",
             "add",
-            "--kind",
-            "feed",
-            "--label",
+            "--name",
             "Example Atom Feed",
-            "--feed-url",
             atom_feed.as_uri(),
         ]
     )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1157,6 +1157,29 @@ def test_youtube_urls_infer_youtube_kind(tmp_path: Path) -> None:
     assert sources[0].transcript_languages == ["en"]
 
 
+def test_regular_youtube_urls_do_not_infer_youtube_kind(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--name",
+            "Example Video",
+            "https://www.youtube.com/watch?v=abc123",
+        ]
+    )
+    assert run(add_args) == 0
+
+    sources = Repository(db_path).list_sources()
+    assert len(sources) == 1
+    assert sources[0].kind == "feed"
+    assert sources[0].transcript_languages == []
+
+
 def test_youtube_sources_default_transcript_language_to_english(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -198,7 +198,7 @@ def test_scan_and_query(tmp_path: Path) -> None:
     assert any(source.costs_money for source in repo.list_sources() if source.kind == "x")
 
     source_id = next(
-        source.id for source in repo.list_sources() if source.label == "Example Channel"
+        source.id for source in repo.list_sources() if source.name == "Example Channel"
     )
     source_show_buffer = io.StringIO()
     with redirect_stdout(source_show_buffer):
@@ -207,7 +207,7 @@ def test_scan_and_query(tmp_path: Path) -> None:
     source_shown = json.loads(source_show_buffer.getvalue())
     assert source_shown["source_id"] == source_id
     assert source_shown["kind"] == "youtube"
-    assert source_shown["label"] == "Example Channel"
+    assert source_shown["name"] == "Example Channel"
     assert source_shown["transcript_languages"] == ["en"]
     assert source_shown["item_count"] == 1
     assert source_shown["logical_item_size_bytes"] > 0
@@ -277,13 +277,13 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
     failing = SourceConfig(
         id="bad-source",
         kind="feed",
-        label="Broken Feed",
+        name="Broken Feed",
         feed_url="https://example.invalid/feed.xml",
     )
     healthy = SourceConfig(
         id="good-source",
         kind="x",
-        label="Healthy Feed",
+        name="Healthy Feed",
         costs_money=True,
         handle="healthy",
         feed_url="https://x.com/healthy",
@@ -387,7 +387,7 @@ def test_scan_skips_paid_sources_without_include_paid(tmp_path: Path) -> None:
         SourceConfig(
             id="paid-source",
             kind="x",
-            label="Paid X",
+            name="Paid X",
             costs_money=True,
             handle="example",
             feed_url="https://x.com/example",
@@ -538,7 +538,7 @@ def test_scan_uses_last_successful_scan_time_for_incremental_blog_and_youtube(
                 assert run(args) == 0
 
         repo = Repository(db_path)
-        sources_by_label = {source.label: source.id for source in repo.list_sources()}
+        sources_by_label = {source.name: source.id for source in repo.list_sources()}
         cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
         blog_source_id = sources_by_label["Example Feed"]
         youtube_source_id = sources_by_label["Example Channel"]
@@ -608,7 +608,7 @@ def test_scan_filters_x_items_using_last_successful_scan_time(tmp_path: Path) ->
         assert run(args) == 0
 
     repo = Repository(db_path)
-    source_id = next(source.id for source in repo.list_sources() if source.label == "Example X")
+    source_id = next(source.id for source in repo.list_sources() if source.name == "Example X")
     cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
     repo.mark_source_scan_succeeded(source_id, cutoff)
 
@@ -720,7 +720,7 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
             assert run(args) == 0
 
     repo = Repository(db_path)
-    sources_by_label = {source.label: source.id for source in repo.list_sources()}
+    sources_by_label = {source.name: source.id for source in repo.list_sources()}
     cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
     repo.mark_source_scan_succeeded(sources_by_label["Example Feed"], cutoff)
     repo.mark_source_scan_succeeded(sources_by_label["Example X"], cutoff)
@@ -775,7 +775,7 @@ def test_scan_records_scan_start_as_success_watermark(tmp_path: Path) -> None:
         SourceConfig(
             id="blog-source",
             kind="feed",
-            label="Example Feed",
+            name="Example Feed",
             feed_url="https://example.com/feed.xml",
         )
     )
@@ -837,20 +837,20 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
     blog_source = SourceConfig(
         id="blog-source",
         kind="feed",
-        label="Example Feed",
+        name="Example Feed",
         feed_url="https://example.com/feed.xml",
     )
     youtube_source = SourceConfig(
         id="youtube-source",
         kind="youtube",
-        label="Example Channel",
+        name="Example Channel",
         feed_url="https://example.com/youtube.xml",
         transcript_languages=["en"],
     )
     x_source = SourceConfig(
         id="x-source",
         kind="x",
-        label="Example X",
+        name="Example X",
         costs_money=True,
         handle="example",
         feed_url="https://x.com/example",
@@ -885,7 +885,7 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
                     external_id=f"{source.id}-1",
                     canonical_url=f"https://example.com/{source.id}/1",
                     title=self.title,
-                    author=source.label,
+                    author=source.name,
                     published_at=None,
                     excerpt=self.title,
                     content_text=self.title,
@@ -925,7 +925,7 @@ def test_scan_can_combine_source_kind_and_source_id_filters(tmp_path: Path) -> N
         SourceConfig(
             id="blog-source",
             kind="feed",
-            label="Example Feed",
+            name="Example Feed",
             feed_url="https://example.com/feed.xml",
         )
     )
@@ -933,7 +933,7 @@ def test_scan_can_combine_source_kind_and_source_id_filters(tmp_path: Path) -> N
         SourceConfig(
             id="youtube-source",
             kind="youtube",
-            label="Example Channel",
+            name="Example Channel",
             feed_url="https://example.com/youtube.xml",
         )
     )
@@ -955,7 +955,7 @@ def test_scan_can_combine_source_kind_and_source_id_filters(tmp_path: Path) -> N
                     external_id="item-1",
                     canonical_url=f"https://example.com/{source.id}/1",
                     title="Matched item",
-                    author=source.label,
+                    author=source.name,
                     published_at=None,
                     excerpt="Matched item",
                     content_text="Matched item",
@@ -1298,6 +1298,7 @@ def test_source_add_help_uses_url_type_and_paid_flags(capsys) -> None:
     assert "Defaults to en." in help_text
     assert "{feed,youtube,x}" in help_text
     assert "blog" not in help_text
+    assert "\"label\"" not in help_text
     assert "--label" not in help_text
     assert "--kind" not in help_text
     assert "--feed-url" not in help_text
@@ -1310,7 +1311,7 @@ def test_source_remove_deletes_source_without_items(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
 
     with redirect_stdout(io.StringIO()) as buffer:
         remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "feed-1"])
@@ -1326,7 +1327,7 @@ def test_source_remove_rejects_non_recursive_delete_when_items_exist(
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
             source_id="feed-1",
@@ -1354,7 +1355,7 @@ def test_source_remove_recursive_deletes_source_and_items(tmp_path: Path) -> Non
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
             source_id="feed-1",
@@ -1593,8 +1594,8 @@ def test_items_show_rejects_ambiguous_title(tmp_path: Path, capsys) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="yt-a", kind="youtube", label="Channel A"))
-    repo.upsert_source(SourceConfig(id="yt-b", kind="youtube", label="Channel B"))
+    repo.upsert_source(SourceConfig(id="yt-a", kind="youtube", name="Channel A"))
+    repo.upsert_source(SourceConfig(id="yt-b", kind="youtube", name="Channel B"))
     for suffix in ("a", "b"):
         repo.upsert_item(
             NormalizedItem(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import io
 import json
+import subprocess
 from contextlib import redirect_stdout
 from datetime import datetime, timezone
 from pathlib import Path
@@ -896,6 +897,155 @@ def test_x_sources_default_to_paid(tmp_path: Path) -> None:
     assert sources[0].costs_money is True
 
 
+def test_x_list_sources_use_xurl_and_store_list_contents(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    list_url = "https://x.com/i/lists/9876543210"
+    expected_target = (
+        "/2/lists/9876543210/tweets"
+        "?expansions=author_id&max_results=100&tweet.fields=created_at&user.fields=username"
+    )
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--kind",
+            "x",
+            "--label",
+            "AI List",
+            "--feed-url",
+            list_url,
+        ]
+    )
+    assert run(add_args) == 0
+
+    original_run = adapters.subprocess.run
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["xurl", expected_target]
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            stdout=json.dumps(
+                {
+                    "items": [
+                        {
+                            "id": "12345",
+                            "text": "Short post on markets",
+                            "created_at": "2026-04-14T15:00:00Z",
+                            "user": {"screen_name": "example"},
+                        }
+                    ]
+                }
+            ),
+            stderr="",
+        )
+
+    adapters.subprocess.run = fake_run
+    try:
+        scan_args = parser.parse_args(
+            ["--db", str(db_path), "scan", "--include-paid"]
+        )
+        assert run(scan_args) == 0
+    finally:
+        adapters.subprocess.run = original_run
+
+    items = Repository(db_path).list_items(limit=10)
+    assert len(items) == 1
+    assert items[0].title == "Short post on markets"
+    assert items[0].canonical_url == "https://x.com/example/status/12345"
+
+
+def test_x_list_browser_url_is_translated_to_list_tweets_api_target() -> None:
+    target = adapters._x_command_target("https://x.com/i/lists/9876543210")
+
+    assert target == (
+        "/2/lists/9876543210/tweets"
+        "?expansions=author_id&max_results=100&tweet.fields=created_at&user.fields=username"
+    )
+
+
+def test_source_remove_deletes_source_without_items(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "blog-1"])
+        assert run(remove_args) == 0
+
+    assert "Removed source blog-1" in buffer.getvalue()
+    assert repo.list_sources() == []
+
+
+def test_source_remove_rejects_non_recursive_delete_when_items_exist(
+    tmp_path: Path, capsys
+) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="blog-1",
+            item_type="blog",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Post One",
+            author="Author",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+
+    remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "blog-1"])
+    assert run(remove_args) == 1
+
+    captured = capsys.readouterr()
+    assert "rerun with --recursive" in captured.err
+    assert [source.id for source in repo.list_sources()] == ["blog-1"]
+    assert len(repo.list_items(limit=10)) == 1
+
+
+def test_source_remove_recursive_deletes_source_and_items(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="blog-1",
+            item_type="blog",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Post One",
+            author="Author",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        remove_args = parser.parse_args(
+            ["--db", str(db_path), "source", "remove", "--recursive", "blog-1"]
+        )
+        assert run(remove_args) == 0
+
+    output = buffer.getvalue()
+    assert "Removed source blog-1 and deleted 1 items" in output
+    assert repo.list_sources() == []
+    assert repo.list_items(limit=10) == []
+
+
 def test_scan_and_query_atom_blog_feed(tmp_path: Path) -> None:
     atom_feed = tmp_path / "atom.xml"
     atom_feed.write_text(
@@ -976,6 +1126,59 @@ def test_items_show_accepts_exact_title(tmp_path: Path) -> None:
     assert shown["title"] == "Daily Briefing"
 
 
+def test_items_remove_accepts_exact_item_id(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="item-1",
+            source_id="yt-1",
+            item_type="video",
+            external_id="abc123",
+            canonical_url="https://youtube.com/watch?v=abc123",
+            title="Daily Briefing",
+            author="Channel",
+            published_at=None,
+            excerpt="Summary",
+            content_text="Transcript",
+        )
+    )
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        remove_args = parser.parse_args(["--db", str(db_path), "items", "remove", "item-1"])
+        assert run(remove_args) == 0
+
+    assert "Removed item item-1" in buffer.getvalue()
+    assert repo.list_items(limit=10) == []
+
+
+def test_items_remove_accepts_exact_title(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="item-1",
+            source_id="yt-1",
+            item_type="video",
+            external_id="abc123",
+            canonical_url="https://youtube.com/watch?v=abc123",
+            title="Daily Briefing",
+            author="Channel",
+            published_at=None,
+            excerpt="Summary",
+            content_text="Transcript",
+        )
+    )
+
+    remove_args = parser.parse_args(
+        ["--db", str(db_path), "items", "remove", "Daily Briefing"]
+    )
+    assert run(remove_args) == 0
+    assert repo.list_items(limit=10) == []
+
+
 def test_items_show_accepts_unique_item_id_prefix(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
@@ -1041,6 +1244,17 @@ def test_items_show_rejects_ambiguous_item_id_prefix(tmp_path: Path, capsys) -> 
     assert "Item ID prefix 'aaaaaaa' is ambiguous" in captured.err
     assert "aaaaaaaa" in captured.err
     assert "aaaaaaab" in captured.err
+
+
+def test_items_remove_rejects_missing_item(tmp_path: Path, capsys) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    remove_args = parser.parse_args(["--db", str(db_path), "items", "remove", "missing"])
+    assert run(remove_args) == 1
+
+    captured = capsys.readouterr()
+    assert "Item missing not found" in captured.err
 
 
 def test_items_show_rejects_ambiguous_title(tmp_path: Path, capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -243,6 +243,7 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
             source: SourceConfig,
             *,
             since: datetime | None = None,
+            verbose=None,
         ) -> list[NormalizedItem]:
             raise HTTPError(source.feed_url or "", 404, "Not Found", hdrs=None, fp=None)
 
@@ -252,6 +253,7 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
             source: SourceConfig,
             *,
             since: datetime | None = None,
+            verbose=None,
         ) -> list[NormalizedItem]:
             return [
                 NormalizedItem(
@@ -331,6 +333,7 @@ def test_scan_skips_paid_sources_without_include_paid(tmp_path: Path) -> None:
             source: SourceConfig,
             *,
             since: datetime | None = None,
+            verbose=None,
         ) -> list[NormalizedItem]:
             raise AssertionError("paid source should have been skipped")
 
@@ -560,6 +563,134 @@ def test_scan_filters_x_items_using_last_successful_scan_time(tmp_path: Path) ->
     assert f"{source_id}: new old post" not in output
 
 
+def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
+    tmp_path: Path,
+) -> None:
+    blog_feed = tmp_path / "blog.xml"
+    blog_feed.write_text(
+        """
+        <rss version="2.0">
+          <channel>
+            <title>Example Blog</title>
+            <item>
+              <title>New Post</title>
+              <link>https://example.com/new-post</link>
+              <guid>post-2</guid>
+              <pubDate>Tue, 14 Apr 2026 13:00:00 +0000</pubDate>
+              <description>Fresh item.</description>
+            </item>
+            <item>
+              <title>Old Post</title>
+              <link>https://example.com/old-post</link>
+              <guid>post-1</guid>
+              <pubDate>Tue, 14 Apr 2026 12:00:00 +0000</pubDate>
+              <description>Existing item.</description>
+            </item>
+          </channel>
+        </rss>
+        """
+    )
+    x_payload = tmp_path / "x.json"
+    x_payload.write_text(
+        json.dumps(
+            {
+                "data": [
+                    {
+                        "id": "2",
+                        "author_id": "u1",
+                        "text": "new post",
+                        "created_at": "2026-04-14T13:00:00Z",
+                    },
+                    {
+                        "id": "1",
+                        "author_id": "u1",
+                        "text": "old post",
+                        "created_at": "2026-04-14T12:00:00Z",
+                    },
+                ],
+                "includes": {"users": [{"id": "u1", "username": "example"}]},
+            }
+        )
+    )
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("database_path: laminar.db\n")
+    db_path = tmp_path / "laminar.db"
+    parser = build_parser()
+
+    with redirect_stdout(io.StringIO()):
+        for args_list in (
+            [
+                "--config",
+                str(config_path),
+                "--db",
+                str(db_path),
+                "source",
+                "add",
+                "--kind",
+                "blog",
+                "--label",
+                "Example Blog",
+                "--feed-url",
+                blog_feed.as_uri(),
+            ],
+            [
+                "--config",
+                str(config_path),
+                "--db",
+                str(db_path),
+                "source",
+                "add",
+                "--kind",
+                "x",
+                "--label",
+                "Example X",
+                "--costs-money",
+                "--handle",
+                "example",
+                "--command",
+                "cat",
+                str(x_payload),
+            ],
+        ):
+            args = parser.parse_args(args_list)
+            assert run(args) == 0
+
+    repo = Repository(db_path)
+    sources_by_label = {source.label: source.id for source in repo.list_sources()}
+    cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
+    repo.mark_source_scan_succeeded(sources_by_label["Example Blog"], cutoff)
+    repo.mark_source_scan_succeeded(sources_by_label["Example X"], cutoff)
+
+    scan_buffer = io.StringIO()
+    with redirect_stdout(scan_buffer):
+        args = parser.parse_args(
+            [
+                "--config",
+                str(config_path),
+                "--db",
+                str(db_path),
+                "--verbose",
+                "scan",
+                "--include-paid",
+            ]
+        )
+        assert run(args) == 0
+
+    output = scan_buffer.getvalue()
+    blog_source_id = sources_by_label["Example Blog"]
+    x_source_id = sources_by_label["Example X"]
+    assert f"{blog_source_id}: incremental cutoff is 2026-04-14T12:30:00+00:00" in output
+    assert (
+        f"{blog_source_id}: stopping rss scan at 2026-04-14T12:00:00+00:00 because it is at or before cutoff 2026-04-14T12:30:00+00:00"
+        in output
+    )
+    assert f"{x_source_id}: x payload yielded 2 candidate posts before cutoff filtering" in output
+    assert (
+        f"{x_source_id}: skipping x post 1 from 2026-04-14T12:00:00+00:00 because it is at or before cutoff 2026-04-14T12:30:00+00:00"
+        in output
+    )
+
+
 def test_scan_records_scan_start_as_success_watermark(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
@@ -597,6 +728,7 @@ def test_scan_records_scan_start_as_success_watermark(tmp_path: Path) -> None:
             source: SourceConfig,
             *,
             since: datetime | None = None,
+            verbose=None,
         ) -> list[NormalizedItem]:
             observed_since.append(since)
             return [returned_item]
@@ -664,6 +796,7 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
             source: SourceConfig,
             *,
             since: datetime | None = None,
+            verbose=None,
         ) -> list[NormalizedItem]:
             return [
                 NormalizedItem(
@@ -739,6 +872,7 @@ def test_scan_can_combine_source_kind_and_source_id_filters(tmp_path: Path) -> N
             source: SourceConfig,
             *,
             since: datetime | None = None,
+            verbose=None,
         ) -> list[NormalizedItem]:
             return [
                 NormalizedItem(
@@ -783,6 +917,26 @@ def test_default_paths_live_under_home(monkeypatch, tmp_path: Path) -> None:
 
     assert args.config == str(tmp_path / ".laminar" / "config.yaml")
     assert args.db is None
+
+
+def test_scan_short_flags_enable_include_paid_and_verbose() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["scan", "-i", "-v"])
+
+    assert args.include_paid is True
+    assert args.verbose is True
+    assert args.global_verbose is False
+
+
+def test_global_verbose_flag_survives_scan_subparser_defaults() -> None:
+    parser = build_parser()
+
+    args = parser.parse_args(["-v", "scan", "-i"])
+
+    assert args.include_paid is True
+    assert args.global_verbose is True
+    assert args.verbose is False
 
 
 def test_source_validate_creates_default_config(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,9 +110,9 @@ def test_scan_and_query(tmp_path: Path) -> None:
                 "source",
                 "add",
                 "--kind",
-                "blog",
+                "feed",
                 "--label",
-                "Example Blog",
+                "Example Feed",
                 "--feed-url",
                 blog_feed.as_uri(),
             ],
@@ -207,7 +207,7 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
 
     failing = SourceConfig(
         id="bad-source",
-        kind="blog",
+        kind="feed",
         label="Broken Feed",
         feed_url="https://example.invalid/feed.xml",
     )
@@ -446,9 +446,9 @@ def test_scan_uses_last_successful_scan_time_for_incremental_blog_and_youtube(
                     "source",
                     "add",
                     "--kind",
-                    "blog",
+                    "feed",
                     "--label",
-                    "Example Blog",
+                    "Example Feed",
                     "--feed-url",
                     blog_feed.as_uri(),
                 ],
@@ -475,7 +475,7 @@ def test_scan_uses_last_successful_scan_time_for_incremental_blog_and_youtube(
         repo = Repository(db_path)
         sources_by_label = {source.label: source.id for source in repo.list_sources()}
         cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
-        blog_source_id = sources_by_label["Example Blog"]
+        blog_source_id = sources_by_label["Example Feed"]
         youtube_source_id = sources_by_label["Example Channel"]
         repo.mark_source_scan_succeeded(blog_source_id, cutoff)
         repo.mark_source_scan_succeeded(youtube_source_id, cutoff)
@@ -627,9 +627,9 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
                 "source",
                 "add",
                 "--kind",
-                "blog",
+                "feed",
                 "--label",
-                "Example Blog",
+                "Example Feed",
                 "--feed-url",
                 blog_feed.as_uri(),
             ],
@@ -658,7 +658,7 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
     repo = Repository(db_path)
     sources_by_label = {source.label: source.id for source in repo.list_sources()}
     cutoff = datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc)
-    repo.mark_source_scan_succeeded(sources_by_label["Example Blog"], cutoff)
+    repo.mark_source_scan_succeeded(sources_by_label["Example Feed"], cutoff)
     repo.mark_source_scan_succeeded(sources_by_label["Example X"], cutoff)
 
     scan_buffer = io.StringIO()
@@ -677,7 +677,7 @@ def test_scan_verbose_reports_incremental_cutoffs_and_skipped_items(
         assert run(args) == 0
 
     output = scan_buffer.getvalue()
-    blog_source_id = sources_by_label["Example Blog"]
+    blog_source_id = sources_by_label["Example Feed"]
     x_source_id = sources_by_label["Example X"]
     assert f"{blog_source_id}: incremental cutoff is 2026-04-14T12:30:00+00:00" in output
     assert (
@@ -700,8 +700,8 @@ def test_scan_records_scan_start_as_success_watermark(tmp_path: Path) -> None:
     repo.upsert_source(
         SourceConfig(
             id="blog-source",
-            kind="blog",
-            label="Example Blog",
+            kind="feed",
+            label="Example Feed",
             feed_url="https://example.com/feed.xml",
         )
     )
@@ -712,7 +712,7 @@ def test_scan_records_scan_start_as_success_watermark(tmp_path: Path) -> None:
     observed_since: list[datetime | None] = []
     returned_item = NormalizedItem(
         source_id="blog-source",
-        item_type="blog",
+        item_type="feed",
         external_id="post-1",
         canonical_url="https://example.com/post-1",
         title="Published During Scan",
@@ -762,8 +762,8 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
     repo = Repository(db_path)
     blog_source = SourceConfig(
         id="blog-source",
-        kind="blog",
-        label="Example Blog",
+        kind="feed",
+        label="Example Feed",
         feed_url="https://example.com/feed.xml",
     )
     youtube_source = SourceConfig(
@@ -802,8 +802,8 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
                 NormalizedItem(
                     source_id=source.id,
                     item_type=(
-                        "blog"
-                        if source.kind == "blog"
+                        "feed"
+                        if source.kind == "feed"
                         else "video"
                         if source.kind == "youtube"
                         else "x_post"
@@ -820,7 +820,7 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
 
     def fake_build_adapter(source: SourceConfig):
         if source.id == "blog-source":
-            return StaticAdapter("Blog item")
+            return StaticAdapter("Feed item")
         if source.id == "youtube-source":
             return StaticAdapter("YouTube item")
         if source.id == "x-source":
@@ -850,8 +850,8 @@ def test_scan_can_combine_source_kind_and_source_id_filters(tmp_path: Path) -> N
     repo.upsert_source(
         SourceConfig(
             id="blog-source",
-            kind="blog",
-            label="Example Blog",
+            kind="feed",
+            label="Example Feed",
             feed_url="https://example.com/feed.xml",
         )
     )
@@ -965,9 +965,9 @@ def test_source_list_reads_sources_from_database(tmp_path: Path) -> None:
             "source",
             "add",
             "--kind",
-            "blog",
+            "feed",
             "--label",
-            "Example Blog",
+            "Example Feed",
             "--feed-url",
             "file:///tmp/feed.xml",
         ]
@@ -979,8 +979,8 @@ def test_source_list_reads_sources_from_database(tmp_path: Path) -> None:
         assert run(list_args) == 0
 
     output = buffer.getvalue().strip()
-    assert "Example Blog" in output
-    assert "blog" in output
+    assert "Example Feed" in output
+    assert "feed" in output
     assert "enabled" in output
     assert "free" in output
     source_id = repo_source_id_from_db(db_path)
@@ -1129,13 +1129,13 @@ def test_source_remove_deletes_source_without_items(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
 
     with redirect_stdout(io.StringIO()) as buffer:
-        remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "blog-1"])
+        remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "feed-1"])
         assert run(remove_args) == 0
 
-    assert "Removed source blog-1" in buffer.getvalue()
+    assert "Removed source feed-1" in buffer.getvalue()
     assert repo.list_sources() == []
 
 
@@ -1145,11 +1145,11 @@ def test_source_remove_rejects_non_recursive_delete_when_items_exist(
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
-            source_id="blog-1",
-            item_type="blog",
+            source_id="feed-1",
+            item_type="feed",
             external_id="post-1",
             canonical_url="https://example.com/post-1",
             title="Post One",
@@ -1160,12 +1160,12 @@ def test_source_remove_rejects_non_recursive_delete_when_items_exist(
         )
     )
 
-    remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "blog-1"])
+    remove_args = parser.parse_args(["--db", str(db_path), "source", "remove", "feed-1"])
     assert run(remove_args) == 1
 
     captured = capsys.readouterr()
     assert "rerun with --recursive" in captured.err
-    assert [source.id for source in repo.list_sources()] == ["blog-1"]
+    assert [source.id for source in repo.list_sources()] == ["feed-1"]
     assert len(repo.list_items(limit=10)) == 1
 
 
@@ -1173,11 +1173,11 @@ def test_source_remove_recursive_deletes_source_and_items(tmp_path: Path) -> Non
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
     repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
-            source_id="blog-1",
-            item_type="blog",
+            source_id="feed-1",
+            item_type="feed",
             external_id="post-1",
             canonical_url="https://example.com/post-1",
             title="Post One",
@@ -1190,12 +1190,12 @@ def test_source_remove_recursive_deletes_source_and_items(tmp_path: Path) -> Non
 
     with redirect_stdout(io.StringIO()) as buffer:
         remove_args = parser.parse_args(
-            ["--db", str(db_path), "source", "remove", "--recursive", "blog-1"]
+            ["--db", str(db_path), "source", "remove", "--recursive", "feed-1"]
         )
         assert run(remove_args) == 0
 
     output = buffer.getvalue()
-    assert "Removed source blog-1 and deleted 1 items" in output
+    assert "Removed source feed-1 and deleted 1 items" in output
     assert repo.list_sources() == []
     assert repo.list_items(limit=10) == []
 
@@ -1228,9 +1228,9 @@ def test_scan_and_query_atom_blog_feed(tmp_path: Path) -> None:
             "source",
             "add",
             "--kind",
-            "blog",
+            "feed",
             "--label",
-            "Example Atom Blog",
+            "Example Atom Feed",
             "--feed-url",
             atom_feed.as_uri(),
         ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -195,6 +195,73 @@ def test_scan_and_query(tmp_path: Path) -> None:
     assert shown["raw_payload"]["transcript_segments"][0]["timestamp"] == "0:00"
     assert any(source.costs_money for source in repo.list_sources() if source.kind == "x")
 
+    source_id = next(
+        source.id for source in repo.list_sources() if source.label == "Example Channel"
+    )
+    source_show_buffer = io.StringIO()
+    with redirect_stdout(source_show_buffer):
+        source_show_args = parser.parse_args(["--db", str(db_path), "source", "show", source_id])
+        assert run(source_show_args) == 0
+    source_shown = json.loads(source_show_buffer.getvalue())
+    assert source_shown["source_id"] == source_id
+    assert source_shown["kind"] == "youtube"
+    assert source_shown["label"] == "Example Channel"
+    assert source_shown["transcript_languages"] == ["en"]
+    assert source_shown["item_count"] == 1
+    assert source_shown["logical_item_size_bytes"] > 0
+
+    stats_buffer = io.StringIO()
+    with redirect_stdout(stats_buffer):
+        stats_args = parser.parse_args(["--db", str(db_path), "stats"])
+        assert run(stats_args) == 0
+    stats_output = stats_buffer.getvalue()
+    assert "Overview" in stats_output
+    assert "Sources by Kind" in stats_output
+    assert "Items by Source" in stats_output
+    assert "Logical Item Size" in stats_output
+    assert "3" in stats_output
+    assert "Example Feed" in stats_output
+    assert "Example Channel" in stats_output
+    assert "Example X" in stats_output
+    assert "youtube" in stats_output
+    assert "B" in stats_output
+
+
+def test_source_show_reports_missing_source(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    result = run(parser.parse_args(["--db", str(db_path), "source", "show", "missing"]))
+
+    assert result == 1
+
+
+def test_stats_include_items_without_matching_source(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="missing-source",
+            item_type="feed",
+            external_id="orphan-1",
+            canonical_url="https://example.com/orphan-1",
+            title="Orphaned Post",
+            author="Unknown",
+            published_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+            excerpt="Missing source",
+            content_text="Missing source content",
+        )
+    )
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        args = parser.parse_args(["--db", str(db_path), "stats"])
+        assert run(args) == 0
+
+    output = buffer.getvalue()
+    assert "missing-source" in output
+    assert "missing" in output
+
 
 def test_scan_continues_after_source_failure_and_reports_item_statuses(
     tmp_path: Path,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,7 +2,12 @@ from pathlib import Path
 
 import pytest
 
-from laminar.config import ConfigError, ensure_default_config, validate_source
+from laminar.config import (
+    ConfigError,
+    ensure_default_config,
+    normalize_source_kind,
+    validate_source,
+)
 from laminar.models import SourceConfig
 
 
@@ -43,3 +48,7 @@ def test_x_sources_still_require_a_command_or_url() -> None:
         match="x sources require command, feed_url, or api_url",
     ):
         validate_source(source)
+
+
+def test_normalizes_legacy_blog_kind_to_feed() -> None:
+    assert normalize_source_kind("blog") == "feed"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,9 @@
 from pathlib import Path
 
-from laminar.config import ensure_default_config
+import pytest
+
+from laminar.config import ConfigError, ensure_default_config, validate_source
+from laminar.models import SourceConfig
 
 
 def test_loads_database_path_from_config(tmp_path: Path) -> None:
@@ -19,3 +22,24 @@ def test_creates_default_config_file(tmp_path: Path) -> None:
 
     assert config_path.exists()
     assert runtime.database_path == tmp_path / "laminar.db"
+
+
+def test_x_sources_can_validate_with_feed_url() -> None:
+    source = SourceConfig(
+        id="x-list",
+        kind="x",
+        label="Example List",
+        feed_url="https://x.com/i/lists/1234567890",
+    )
+
+    validate_source(source)
+
+
+def test_x_sources_still_require_a_command_or_url() -> None:
+    source = SourceConfig(id="x-empty", kind="x", label="Broken X")
+
+    with pytest.raises(
+        ConfigError,
+        match="x sources require command, feed_url, or api_url",
+    ):
+        validate_source(source)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ import pytest
 from laminar.config import (
     ConfigError,
     ensure_default_config,
-    normalize_source_kind,
     validate_source,
 )
 from laminar.models import SourceConfig
@@ -40,15 +39,11 @@ def test_x_sources_can_validate_with_feed_url() -> None:
     validate_source(source)
 
 
-def test_x_sources_still_require_a_command_or_url() -> None:
+def test_x_sources_still_require_a_url_or_api_url() -> None:
     source = SourceConfig(id="x-empty", kind="x", label="Broken X")
 
     with pytest.raises(
         ConfigError,
-        match="x sources require command, feed_url, or api_url",
+        match="x sources require feed_url or api_url",
     ):
         validate_source(source)
-
-
-def test_normalizes_legacy_blog_kind_to_feed() -> None:
-    assert normalize_source_kind("blog") == "feed"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -32,7 +32,7 @@ def test_x_sources_can_validate_with_feed_url() -> None:
     source = SourceConfig(
         id="x-list",
         kind="x",
-        label="Example List",
+        name="Example List",
         feed_url="https://x.com/i/lists/1234567890",
     )
 
@@ -40,7 +40,7 @@ def test_x_sources_can_validate_with_feed_url() -> None:
 
 
 def test_x_sources_still_require_a_url_or_api_url() -> None:
-    source = SourceConfig(id="x-empty", kind="x", label="Broken X")
+    source = SourceConfig(id="x-empty", kind="x", name="Broken X")
 
     with pytest.raises(
         ConfigError,

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -139,23 +139,56 @@ def test_x_sources_are_treated_as_paid_when_loading_legacy_rows(tmp_path: Path) 
     assert sources[0].costs_money is True
 
 
+def test_legacy_blog_sources_load_as_feed(tmp_path: Path) -> None:
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    with repo.connect() as conn:
+        conn.execute(
+            """
+            INSERT INTO sources (
+                source_id, kind, label, enabled, costs_money, provider, feed_url, handle,
+                command_json, transcript_languages_json, poll_interval_minutes, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "blog-legacy",
+                "blog",
+                "Legacy Blog",
+                1,
+                0,
+                None,
+                "https://example.com/feed.xml",
+                None,
+                "[]",
+                "[]",
+                None,
+                "{}",
+            ),
+        )
+
+    sources = repo.list_sources()
+
+    assert len(sources) == 1
+    assert sources[0].kind == "feed"
+
+
 def test_records_last_successful_scan_time(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
 
     scanned_at = datetime(2026, 4, 14, 18, 30, tzinfo=timezone.utc)
-    repo.mark_source_scan_succeeded("blog-1", scanned_at)
+    repo.mark_source_scan_succeeded("feed-1", scanned_at)
 
-    assert repo.last_successful_scan_at("blog-1") == scanned_at
+    assert repo.last_successful_scan_at("feed-1") == scanned_at
 
 
 def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
-            source_id="blog-1",
-            item_type="blog",
+            source_id="feed-1",
+            item_type="feed",
             external_id="post-1",
             canonical_url="https://example.com/post-1",
             title="Post One",
@@ -170,17 +203,17 @@ def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> No
         ValueError,
         match="still has 1 items; rerun with --recursive",
     ):
-        repo.remove_source("blog-1")
+        repo.remove_source("feed-1")
 
 
 def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
-    repo.start_scan("blog-1")
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.start_scan("feed-1")
     repo.upsert_item(
         NormalizedItem(
-            source_id="blog-1",
-            item_type="blog",
+            source_id="feed-1",
+            item_type="feed",
             external_id="post-1",
             canonical_url="https://example.com/post-1",
             title="Shared Title",
@@ -190,11 +223,11 @@ def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) 
             content_text="One",
         )
     )
-    repo.upsert_source(SourceConfig(id="blog-2", kind="blog", label="Other Blog"))
+    repo.upsert_source(SourceConfig(id="feed-2", kind="feed", label="Other Feed"))
     repo.upsert_item(
         NormalizedItem(
-            source_id="blog-2",
-            item_type="blog",
+            source_id="feed-2",
+            item_type="feed",
             external_id="post-2",
             canonical_url="https://example.com/post-2",
             title="Shared Title",
@@ -205,28 +238,28 @@ def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) 
         )
     )
 
-    removed_items = repo.remove_source("blog-1", recursive=True)
+    removed_items = repo.remove_source("feed-1", recursive=True)
 
     assert removed_items == 1
-    assert [source.id for source in repo.list_sources()] == ["blog-2"]
+    assert [source.id for source in repo.list_sources()] == ["feed-2"]
     items = repo.list_items(limit=10)
     assert len(items) == 1
-    assert items[0].source_id == "blog-2"
+    assert items[0].source_id == "feed-2"
     matches = repo.find_items_by_title("Shared Title")
     assert len(matches) == 1
-    assert matches[0].source_id == "blog-2"
+    assert matches[0].source_id == "feed-2"
     with repo.connect() as conn:
         assert conn.execute(
             "SELECT COUNT(*) FROM scans WHERE source_id = ?",
-            ("blog-1",),
+            ("feed-1",),
         ).fetchone()[0] == 0
 
 
 def test_dedupes_by_canonical_url(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
     first = NormalizedItem(
-        source_id="blog-1",
-        item_type="blog",
+        source_id="feed-1",
+        item_type="feed",
         external_id="1",
         canonical_url="https://example.com/post",
         title="First title",
@@ -236,8 +269,8 @@ def test_dedupes_by_canonical_url(tmp_path: Path) -> None:
         content_text="One",
     )
     second = NormalizedItem(
-        source_id="blog-2",
-        item_type="blog",
+        source_id="feed-2",
+        item_type="feed",
         external_id="2",
         canonical_url="https://example.com/post",
         title="Updated title",

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -3,6 +3,8 @@ from pathlib import Path
 import sqlite3
 from uuid import UUID
 
+import pytest
+
 from laminar.models import NormalizedItem, SourceConfig
 from laminar.repository import Repository
 
@@ -145,6 +147,79 @@ def test_records_last_successful_scan_time(tmp_path: Path) -> None:
     repo.mark_source_scan_succeeded("blog-1", scanned_at)
 
     assert repo.last_successful_scan_at("blog-1") == scanned_at
+
+
+def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="blog-1",
+            item_type="blog",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Post One",
+            author="Author",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="still has 1 items; rerun with --recursive",
+    ):
+        repo.remove_source("blog-1")
+
+
+def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    repo.upsert_source(SourceConfig(id="blog-1", kind="blog", label="Example Blog"))
+    repo.start_scan("blog-1")
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="blog-1",
+            item_type="blog",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Shared Title",
+            author="Author",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+    repo.upsert_source(SourceConfig(id="blog-2", kind="blog", label="Other Blog"))
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="blog-2",
+            item_type="blog",
+            external_id="post-2",
+            canonical_url="https://example.com/post-2",
+            title="Shared Title",
+            author="Author",
+            published_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+            excerpt="Two",
+            content_text="Two",
+        )
+    )
+
+    removed_items = repo.remove_source("blog-1", recursive=True)
+
+    assert removed_items == 1
+    assert [source.id for source in repo.list_sources()] == ["blog-2"]
+    items = repo.list_items(limit=10)
+    assert len(items) == 1
+    assert items[0].source_id == "blog-2"
+    matches = repo.find_items_by_title("Shared Title")
+    assert len(matches) == 1
+    assert matches[0].source_id == "blog-2"
+    with repo.connect() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM scans WHERE source_id = ?",
+            ("blog-1",),
+        ).fetchone()[0] == 0
 
 
 def test_dedupes_by_canonical_url(tmp_path: Path) -> None:
@@ -330,6 +405,59 @@ def test_find_items_by_title_returns_exact_matches(tmp_path: Path) -> None:
 
     assert len(matches) == 1
     assert matches[0].title == "Daily Briefing"
+
+
+def test_remove_item_deletes_content_and_refreshes_title_map(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", label="Channel One"))
+    repo.upsert_source(SourceConfig(id="yt-2", kind="youtube", label="Channel Two"))
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="item-1",
+            source_id="yt-1",
+            item_type="video",
+            external_id="abc123",
+            canonical_url="https://youtube.com/watch?v=abc123",
+            title="Daily Briefing",
+            author="Channel One",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="item-2",
+            source_id="yt-2",
+            item_type="video",
+            external_id="abc124",
+            canonical_url="https://youtube.com/watch?v=abc124",
+            title="Daily Briefing",
+            author="Channel Two",
+            published_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+            excerpt="Two",
+            content_text="Two",
+        )
+    )
+
+    assert repo.remove_item("item-1") is True
+    assert repo.get_item("item-1") is None
+    assert repo.find_items_by_title("Daily Briefing (Channel One)") == []
+    matches = repo.find_items_by_title("Daily Briefing")
+    assert len(matches) == 1
+    assert matches[0].item_id == "item-2"
+
+    with repo.connect() as conn:
+        assert conn.execute(
+            "SELECT COUNT(*) FROM item_contents WHERE item_id = ?",
+            ("item-1",),
+        ).fetchone()[0] == 0
+
+
+def test_remove_item_returns_false_when_missing(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+
+    assert repo.remove_item("missing-item") is False
 
 
 def test_title_map_updates_when_item_title_changes(tmp_path: Path) -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -19,9 +19,7 @@ def test_persists_source_config_round_trip(tmp_path: Path) -> None:
             enabled=False,
             costs_money=True,
             feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
-            command=["unused"],
             transcript_languages=["en", "es"],
-            poll_interval_minutes=30,
             metadata={"region": "us"},
         )
     )
@@ -33,7 +31,6 @@ def test_persists_source_config_round_trip(tmp_path: Path) -> None:
     assert sources[0].enabled is False
     assert sources[0].costs_money is True
     assert sources[0].transcript_languages == ["en", "es"]
-    assert sources[0].poll_interval_minutes == 30
     assert sources[0].metadata["region"] == "us"
 
 
@@ -47,12 +44,9 @@ def test_adds_costs_money_column_for_existing_databases(tmp_path: Path) -> None:
             kind TEXT NOT NULL,
             label TEXT NOT NULL,
             enabled INTEGER NOT NULL,
-            provider TEXT,
             feed_url TEXT,
             handle TEXT,
-            command_json TEXT NOT NULL DEFAULT '[]',
             transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            poll_interval_minutes INTEGER,
             metadata_json TEXT NOT NULL,
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
@@ -81,12 +75,9 @@ def test_adds_last_successful_scan_column_for_existing_databases(tmp_path: Path)
             label TEXT NOT NULL,
             enabled INTEGER NOT NULL,
             costs_money INTEGER NOT NULL DEFAULT 0,
-            provider TEXT,
             feed_url TEXT,
             handle TEXT,
-            command_json TEXT NOT NULL DEFAULT '[]',
             transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            poll_interval_minutes INTEGER,
             metadata_json TEXT NOT NULL,
             updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
         );
@@ -105,71 +96,159 @@ def test_adds_last_successful_scan_column_for_existing_databases(tmp_path: Path)
     assert "last_successful_scan_at" in columns
 
 
+def test_migrates_sources_table_to_clean_schema(tmp_path: Path) -> None:
+    db_path = tmp_path / "laminar.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE sources (
+            source_id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            label TEXT NOT NULL,
+            enabled INTEGER NOT NULL,
+            provider TEXT,
+            feed_url TEXT,
+            handle TEXT,
+            command_json TEXT NOT NULL DEFAULT '[]',
+            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
+            poll_interval_minutes INTEGER,
+            metadata_json TEXT NOT NULL,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO sources (
+            source_id, kind, label, enabled, provider, feed_url, handle,
+            command_json, transcript_languages_json, poll_interval_minutes, metadata_json
+        ) VALUES (
+            'yt-1', 'youtube', 'Example Channel', 1, 'youtube',
+            'https://www.youtube.com/feeds/videos.xml?channel_id=123', '@example',
+            '["unused"]', '["en"]', 30, '{"region":"us"}'
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    repo = Repository(db_path)
+
+    with repo.connect() as conn:
+        columns = [
+            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
+        ]
+
+    assert columns == [
+        "source_id",
+        "kind",
+        "label",
+        "enabled",
+        "costs_money",
+        "feed_url",
+        "handle",
+        "transcript_languages_json",
+        "metadata_json",
+        "last_successful_scan_at",
+        "updated_at",
+    ]
+
+    source = repo.get_source("yt-1")
+    assert source is not None
+    assert source.kind == "youtube"
+    assert source.label == "Example Channel"
+    assert source.enabled is True
+    assert source.costs_money is False
+    assert source.feed_url == "https://www.youtube.com/feeds/videos.xml?channel_id=123"
+    assert source.handle == "@example"
+    assert source.transcript_languages == ["en"]
+    assert source.metadata == {"region": "us"}
+
+
 def test_x_sources_are_treated_as_paid_when_loading_legacy_rows(tmp_path: Path) -> None:
     db_path = tmp_path / "laminar.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE sources (
+            source_id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            label TEXT NOT NULL,
+            enabled INTEGER NOT NULL,
+            costs_money INTEGER NOT NULL DEFAULT 0,
+            feed_url TEXT,
+            handle TEXT,
+            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
+            metadata_json TEXT NOT NULL,
+            last_successful_scan_at TEXT,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO sources (
+            source_id, kind, label, enabled, costs_money, feed_url, handle,
+            transcript_languages_json, metadata_json
+        ) VALUES (
+            'x-legacy', 'x', 'Jeremy Howard', 1, 0, NULL, 'jeremyphoward', '[]', '{}'
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
     repo = Repository(db_path)
-    with repo.connect() as conn:
-        conn.execute(
-            """
-            INSERT INTO sources (
-                source_id, kind, label, enabled, costs_money, provider, feed_url, handle,
-                command_json, transcript_languages_json, poll_interval_minutes, metadata_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "x-legacy",
-                "x",
-                "Jeremy Howard",
-                1,
-                0,
-                None,
-                None,
-                "jeremyphoward",
-                "[]",
-                "[]",
-                None,
-                "{}",
-            ),
-        )
 
     sources = repo.list_sources()
 
     assert len(sources) == 1
     assert sources[0].kind == "x"
     assert sources[0].costs_money is True
+    with repo.connect() as conn:
+        stored = conn.execute(
+            "SELECT kind, costs_money FROM sources WHERE source_id = ?",
+            ("x-legacy",),
+        ).fetchone()
+    assert stored is not None
+    assert stored["kind"] == "x"
+    assert stored["costs_money"] == 1
 
 
 def test_legacy_blog_sources_load_as_feed(tmp_path: Path) -> None:
     db_path = tmp_path / "laminar.db"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE sources (
+            source_id TEXT PRIMARY KEY,
+            kind TEXT NOT NULL,
+            label TEXT NOT NULL,
+            enabled INTEGER NOT NULL,
+            costs_money INTEGER NOT NULL DEFAULT 0,
+            feed_url TEXT,
+            handle TEXT,
+            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
+            metadata_json TEXT NOT NULL,
+            last_successful_scan_at TEXT,
+            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+        INSERT INTO sources (
+            source_id, kind, label, enabled, costs_money, feed_url, handle,
+            transcript_languages_json, metadata_json
+        ) VALUES (
+            'blog-legacy', 'blog', 'Legacy Blog', 1, 0, 'https://example.com/feed.xml', NULL, '[]', '{}'
+        );
+        """
+    )
+    conn.commit()
+    conn.close()
+
     repo = Repository(db_path)
-    with repo.connect() as conn:
-        conn.execute(
-            """
-            INSERT INTO sources (
-                source_id, kind, label, enabled, costs_money, provider, feed_url, handle,
-                command_json, transcript_languages_json, poll_interval_minutes, metadata_json
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                "blog-legacy",
-                "blog",
-                "Legacy Blog",
-                1,
-                0,
-                None,
-                "https://example.com/feed.xml",
-                None,
-                "[]",
-                "[]",
-                None,
-                "{}",
-            ),
-        )
 
     sources = repo.list_sources()
 
     assert len(sources) == 1
     assert sources[0].kind == "feed"
+    with repo.connect() as conn:
+        stored = conn.execute(
+            "SELECT kind FROM sources WHERE source_id = ?",
+            ("blog-legacy",),
+        ).fetchone()
+    assert stored is not None
+    assert stored["kind"] == "feed"
 
 
 def test_records_last_successful_scan_time(tmp_path: Path) -> None:
@@ -192,12 +271,9 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
             label="Example Channel",
             enabled=False,
             costs_money=True,
-            provider="youtube",
             feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
             handle="@example",
-            command=["yt-dlp", "--flat-playlist"],
             transcript_languages=["en", "es"],
-            poll_interval_minutes=30,
             metadata={"region": "us"},
         )
     )
@@ -210,12 +286,9 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
     assert source.label == "Example Channel"
     assert source.enabled is False
     assert source.costs_money is True
-    assert source.provider == "youtube"
     assert source.feed_url == "https://www.youtube.com/feeds/videos.xml?channel_id=123"
     assert source.handle == "@example"
-    assert source.command == ["yt-dlp", "--flat-playlist"]
     assert source.transcript_languages == ["en", "es"]
-    assert source.poll_interval_minutes == 30
     assert source.metadata == {"region": "us"}
     assert source.last_successful_scan_at == scanned_at
 

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,6 +1,5 @@
 from datetime import datetime, timezone
 from pathlib import Path
-import sqlite3
 from uuid import UUID
 
 import pytest
@@ -15,7 +14,7 @@ def test_persists_source_config_round_trip(tmp_path: Path) -> None:
         SourceConfig(
             id="yt-1",
             kind="youtube",
-            label="Example Channel",
+            name="Example Channel",
             enabled=False,
             costs_money=True,
             feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
@@ -34,226 +33,9 @@ def test_persists_source_config_round_trip(tmp_path: Path) -> None:
     assert sources[0].metadata["region"] == "us"
 
 
-def test_adds_costs_money_column_for_existing_databases(tmp_path: Path) -> None:
-    db_path = tmp_path / "laminar.db"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE sources (
-            source_id TEXT PRIMARY KEY,
-            kind TEXT NOT NULL,
-            label TEXT NOT NULL,
-            enabled INTEGER NOT NULL,
-            feed_url TEXT,
-            handle TEXT,
-            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            metadata_json TEXT NOT NULL,
-            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        """
-    )
-    conn.commit()
-    conn.close()
-
-    repo = Repository(db_path)
-    repo.upsert_source(SourceConfig(id="x-1", kind="x", label="Paid X", costs_money=True))
-
-    sources = repo.list_sources()
-
-    assert len(sources) == 1
-    assert sources[0].costs_money is True
-
-
-def test_adds_last_successful_scan_column_for_existing_databases(tmp_path: Path) -> None:
-    db_path = tmp_path / "laminar.db"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE sources (
-            source_id TEXT PRIMARY KEY,
-            kind TEXT NOT NULL,
-            label TEXT NOT NULL,
-            enabled INTEGER NOT NULL,
-            costs_money INTEGER NOT NULL DEFAULT 0,
-            feed_url TEXT,
-            handle TEXT,
-            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            metadata_json TEXT NOT NULL,
-            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        """
-    )
-    conn.commit()
-    conn.close()
-
-    repo = Repository(db_path)
-
-    with repo.connect() as conn:
-        columns = {
-            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
-        }
-
-    assert "last_successful_scan_at" in columns
-
-
-def test_migrates_sources_table_to_clean_schema(tmp_path: Path) -> None:
-    db_path = tmp_path / "laminar.db"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE sources (
-            source_id TEXT PRIMARY KEY,
-            kind TEXT NOT NULL,
-            label TEXT NOT NULL,
-            enabled INTEGER NOT NULL,
-            provider TEXT,
-            feed_url TEXT,
-            handle TEXT,
-            command_json TEXT NOT NULL DEFAULT '[]',
-            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            poll_interval_minutes INTEGER,
-            metadata_json TEXT NOT NULL,
-            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        INSERT INTO sources (
-            source_id, kind, label, enabled, provider, feed_url, handle,
-            command_json, transcript_languages_json, poll_interval_minutes, metadata_json
-        ) VALUES (
-            'yt-1', 'youtube', 'Example Channel', 1, 'youtube',
-            'https://www.youtube.com/feeds/videos.xml?channel_id=123', '@example',
-            '["unused"]', '["en"]', 30, '{"region":"us"}'
-        );
-        """
-    )
-    conn.commit()
-    conn.close()
-
-    repo = Repository(db_path)
-
-    with repo.connect() as conn:
-        columns = [
-            str(row["name"]) for row in conn.execute("PRAGMA table_info(sources)").fetchall()
-        ]
-
-    assert columns == [
-        "source_id",
-        "kind",
-        "label",
-        "enabled",
-        "costs_money",
-        "feed_url",
-        "handle",
-        "transcript_languages_json",
-        "metadata_json",
-        "last_successful_scan_at",
-        "updated_at",
-    ]
-
-    source = repo.get_source("yt-1")
-    assert source is not None
-    assert source.kind == "youtube"
-    assert source.label == "Example Channel"
-    assert source.enabled is True
-    assert source.costs_money is False
-    assert source.feed_url == "https://www.youtube.com/feeds/videos.xml?channel_id=123"
-    assert source.handle == "@example"
-    assert source.transcript_languages == ["en"]
-    assert source.metadata == {"region": "us"}
-
-
-def test_x_sources_are_treated_as_paid_when_loading_legacy_rows(tmp_path: Path) -> None:
-    db_path = tmp_path / "laminar.db"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE sources (
-            source_id TEXT PRIMARY KEY,
-            kind TEXT NOT NULL,
-            label TEXT NOT NULL,
-            enabled INTEGER NOT NULL,
-            costs_money INTEGER NOT NULL DEFAULT 0,
-            feed_url TEXT,
-            handle TEXT,
-            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            metadata_json TEXT NOT NULL,
-            last_successful_scan_at TEXT,
-            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        INSERT INTO sources (
-            source_id, kind, label, enabled, costs_money, feed_url, handle,
-            transcript_languages_json, metadata_json
-        ) VALUES (
-            'x-legacy', 'x', 'Jeremy Howard', 1, 0, NULL, 'jeremyphoward', '[]', '{}'
-        );
-        """
-    )
-    conn.commit()
-    conn.close()
-
-    repo = Repository(db_path)
-
-    sources = repo.list_sources()
-
-    assert len(sources) == 1
-    assert sources[0].kind == "x"
-    assert sources[0].costs_money is True
-    with repo.connect() as conn:
-        stored = conn.execute(
-            "SELECT kind, costs_money FROM sources WHERE source_id = ?",
-            ("x-legacy",),
-        ).fetchone()
-    assert stored is not None
-    assert stored["kind"] == "x"
-    assert stored["costs_money"] == 1
-
-
-def test_legacy_blog_sources_load_as_feed(tmp_path: Path) -> None:
-    db_path = tmp_path / "laminar.db"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE sources (
-            source_id TEXT PRIMARY KEY,
-            kind TEXT NOT NULL,
-            label TEXT NOT NULL,
-            enabled INTEGER NOT NULL,
-            costs_money INTEGER NOT NULL DEFAULT 0,
-            feed_url TEXT,
-            handle TEXT,
-            transcript_languages_json TEXT NOT NULL DEFAULT '[]',
-            metadata_json TEXT NOT NULL,
-            last_successful_scan_at TEXT,
-            updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
-        );
-        INSERT INTO sources (
-            source_id, kind, label, enabled, costs_money, feed_url, handle,
-            transcript_languages_json, metadata_json
-        ) VALUES (
-            'blog-legacy', 'blog', 'Legacy Blog', 1, 0, 'https://example.com/feed.xml', NULL, '[]', '{}'
-        );
-        """
-    )
-    conn.commit()
-    conn.close()
-
-    repo = Repository(db_path)
-
-    sources = repo.list_sources()
-
-    assert len(sources) == 1
-    assert sources[0].kind == "feed"
-    with repo.connect() as conn:
-        stored = conn.execute(
-            "SELECT kind FROM sources WHERE source_id = ?",
-            ("blog-legacy",),
-        ).fetchone()
-    assert stored is not None
-    assert stored["kind"] == "feed"
-
-
 def test_records_last_successful_scan_time(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
 
     scanned_at = datetime(2026, 4, 14, 18, 30, tzinfo=timezone.utc)
     repo.mark_source_scan_succeeded("feed-1", scanned_at)
@@ -268,7 +50,7 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
         SourceConfig(
             id="yt-1",
             kind="youtube",
-            label="Example Channel",
+            name="Example Channel",
             enabled=False,
             costs_money=True,
             feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
@@ -283,7 +65,7 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
 
     assert source is not None
     assert source.id == "yt-1"
-    assert source.label == "Example Channel"
+    assert source.name == "Example Channel"
     assert source.enabled is False
     assert source.costs_money is True
     assert source.feed_url == "https://www.youtube.com/feeds/videos.xml?channel_id=123"
@@ -295,13 +77,13 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
 
 def test_stats_reports_totals_by_source_and_kind(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
-    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", label="Example Channel"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
+    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", name="Example Channel"))
     repo.upsert_source(
         SourceConfig(
             id="x-1",
             kind="x",
-            label="Example X",
+            name="Example X",
             costs_money=True,
             enabled=False,
         )
@@ -375,7 +157,7 @@ def test_stats_reports_totals_by_source_and_kind(tmp_path: Path) -> None:
 
 def test_stats_include_items_without_matching_source(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
             source_id="feed-1",
@@ -410,7 +192,7 @@ def test_stats_include_items_without_matching_source(tmp_path: Path) -> None:
     assert stats.total_sources == 1
     assert stats.total_items == 2
     assert "missing-source" in sources_by_id
-    assert sources_by_id["missing-source"].label == "[missing source]"
+    assert sources_by_id["missing-source"].name == "[missing source]"
     assert sources_by_id["missing-source"].kind == "missing"
     assert sources_by_id["missing-source"].enabled is False
     assert sources_by_id["missing-source"].costs_money is False
@@ -423,7 +205,7 @@ def test_stats_include_items_without_matching_source(tmp_path: Path) -> None:
 
 def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
     repo.upsert_item(
         NormalizedItem(
             source_id="feed-1",
@@ -447,7 +229,7 @@ def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> No
 
 def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
     repo.start_scan("feed-1")
     repo.upsert_item(
         NormalizedItem(
@@ -462,7 +244,7 @@ def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) 
             content_text="One",
         )
     )
-    repo.upsert_source(SourceConfig(id="feed-2", kind="feed", label="Other Feed"))
+    repo.upsert_source(SourceConfig(id="feed-2", kind="feed", name="Other Feed"))
     repo.upsert_item(
         NormalizedItem(
             source_id="feed-2",
@@ -681,8 +463,8 @@ def test_find_items_by_title_returns_exact_matches(tmp_path: Path) -> None:
 
 def test_remove_item_deletes_content_and_refreshes_title_map(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", label="Channel One"))
-    repo.upsert_source(SourceConfig(id="yt-2", kind="youtube", label="Channel Two"))
+    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", name="Channel One"))
+    repo.upsert_source(SourceConfig(id="yt-2", kind="youtube", name="Channel Two"))
     repo.upsert_item(
         NormalizedItem(
             item_id="item-1",
@@ -738,7 +520,7 @@ def test_title_map_updates_when_item_title_changes(tmp_path: Path) -> None:
         SourceConfig(
             id="yt-1",
             kind="youtube",
-            label="Channel One",
+            name="Channel One",
         )
     )
     item = NormalizedItem(
@@ -776,8 +558,8 @@ def test_title_map_updates_when_item_title_changes(tmp_path: Path) -> None:
 
 def test_title_map_uses_source_name_for_collisions(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", label="Channel One"))
-    repo.upsert_source(SourceConfig(id="yt-2", kind="youtube", label="Channel Two"))
+    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", name="Channel One"))
+    repo.upsert_source(SourceConfig(id="yt-2", kind="youtube", name="Channel Two"))
     repo.upsert_item(
         NormalizedItem(
             source_id="yt-1",

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -182,6 +182,172 @@ def test_records_last_successful_scan_time(tmp_path: Path) -> None:
     assert repo.last_successful_scan_at("feed-1") == scanned_at
 
 
+def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    scanned_at = datetime(2026, 4, 14, 18, 30, tzinfo=timezone.utc)
+    repo.upsert_source(
+        SourceConfig(
+            id="yt-1",
+            kind="youtube",
+            label="Example Channel",
+            enabled=False,
+            costs_money=True,
+            provider="youtube",
+            feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
+            handle="@example",
+            command=["yt-dlp", "--flat-playlist"],
+            transcript_languages=["en", "es"],
+            poll_interval_minutes=30,
+            metadata={"region": "us"},
+        )
+    )
+    repo.mark_source_scan_succeeded("yt-1", scanned_at)
+
+    source = repo.get_source("yt-1")
+
+    assert source is not None
+    assert source.id == "yt-1"
+    assert source.label == "Example Channel"
+    assert source.enabled is False
+    assert source.costs_money is True
+    assert source.provider == "youtube"
+    assert source.feed_url == "https://www.youtube.com/feeds/videos.xml?channel_id=123"
+    assert source.handle == "@example"
+    assert source.command == ["yt-dlp", "--flat-playlist"]
+    assert source.transcript_languages == ["en", "es"]
+    assert source.poll_interval_minutes == 30
+    assert source.metadata == {"region": "us"}
+    assert source.last_successful_scan_at == scanned_at
+
+
+def test_stats_reports_totals_by_source_and_kind(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_source(SourceConfig(id="yt-1", kind="youtube", label="Example Channel"))
+    repo.upsert_source(
+        SourceConfig(
+            id="x-1",
+            kind="x",
+            label="Example X",
+            costs_money=True,
+            enabled=False,
+        )
+    )
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="feed-1",
+            item_type="feed",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Post One",
+            author="Author",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="feed-1",
+            item_type="feed",
+            external_id="post-2",
+            canonical_url="https://example.com/post-2",
+            title="Post Two",
+            author="Author",
+            published_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+            excerpt="Two",
+            content_text="Two",
+        )
+    )
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="yt-1",
+            item_type="video",
+            external_id="video-1",
+            canonical_url="https://youtube.com/watch?v=video-1",
+            title="Video One",
+            author="Channel",
+            published_at=datetime(2026, 4, 16, tzinfo=timezone.utc),
+            excerpt="Video",
+            content_text="Transcript",
+        )
+    )
+
+    stats = repo.stats()
+    sources_by_id = {source.source_id: source for source in stats.sources}
+    kinds_by_name = {kind.kind: kind for kind in stats.kinds}
+
+    assert stats.total_sources == 3
+    assert stats.total_items == 3
+    assert stats.total_size_bytes > 0
+    assert [(source.source_id, source.item_count) for source in stats.sources] == [
+        ("feed-1", 2),
+        ("yt-1", 1),
+        ("x-1", 0),
+    ]
+    assert {
+        kind.kind: (kind.source_count, kind.item_count) for kind in stats.kinds
+    } == {
+        "feed": (1, 2),
+        "x": (1, 0),
+        "youtube": (1, 1),
+    }
+    assert sources_by_id["feed-1"].size_bytes > sources_by_id["yt-1"].size_bytes > 0
+    assert sources_by_id["x-1"].size_bytes == 0
+    assert kinds_by_name["feed"].size_bytes == sources_by_id["feed-1"].size_bytes
+    assert kinds_by_name["youtube"].size_bytes == sources_by_id["yt-1"].size_bytes
+    assert kinds_by_name["x"].size_bytes == 0
+    assert stats.total_size_bytes == sum(source.size_bytes for source in stats.sources)
+
+
+def test_stats_include_items_without_matching_source(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="feed-1",
+            item_type="feed",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Post One",
+            author="Author",
+            published_at=datetime(2026, 4, 14, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        )
+    )
+    repo.upsert_item(
+        NormalizedItem(
+            source_id="missing-source",
+            item_type="feed",
+            external_id="orphan-1",
+            canonical_url="https://example.com/orphan-1",
+            title="Orphaned Post",
+            author="Unknown",
+            published_at=datetime(2026, 4, 15, tzinfo=timezone.utc),
+            excerpt="Missing source",
+            content_text="Missing source content",
+        )
+    )
+
+    stats = repo.stats()
+    sources_by_id = {source.source_id: source for source in stats.sources}
+    kinds_by_name = {kind.kind: kind for kind in stats.kinds}
+
+    assert stats.total_sources == 1
+    assert stats.total_items == 2
+    assert "missing-source" in sources_by_id
+    assert sources_by_id["missing-source"].label == "[missing source]"
+    assert sources_by_id["missing-source"].kind == "missing"
+    assert sources_by_id["missing-source"].enabled is False
+    assert sources_by_id["missing-source"].costs_money is False
+    assert sources_by_id["missing-source"].item_count == 1
+    assert sources_by_id["missing-source"].size_bytes > 0
+    assert kinds_by_name["missing"].source_count == 1
+    assert kinds_by_name["missing"].item_count == 1
+    assert kinds_by_name["missing"].size_bytes == sources_by_id["missing-source"].size_bytes
+
+
 def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
     repo.upsert_source(SourceConfig(id="feed-1", kind="feed", label="Example Feed"))


### PR DESCRIPTION
## Summary
- add X list support and standardize X ingestion around `xurl`
- simplify `source add` by using a required URL, `--name`, and inferred source types
- rename paid-source UX to `--paid`, default X sources to paid, and default YouTube transcript language to English
- remove unused source fields and schema clutter (`provider`, `command`, `poll_interval_minutes`) and rename `label` to `name`
- add `source show`, source stats output, and update docs/tests for the new CLI behavior

## Notes
- `--type` now resolves to `x` for X URLs, `youtube` for YouTube feed URLs, and `feed` otherwise unless explicitly overridden
- regular YouTube page URLs are no longer auto-inferred as `youtube`; only feed endpoints are

## Verification
- `UV_CACHE_DIR=/tmp/laminar-uv-cache uv run pytest -q`