### PR TITLE
[codex] add export/import, scan history, and YouTube API support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 Laminar is a local-first Python CLI for ingesting updates from multiple content sources and storing them in SQLite for deterministic retrieval by downstream agents.
 
 Current source types:
-- blog
+- feed
 - youtube
 - x
 
@@ -27,9 +27,13 @@ Common commands:
 uv sync
 uv run pytest
 uv run laminar source validate
+uv run laminar source export sources.yaml
+uv run laminar source import sources.yaml
 uv run laminar scan
 uv run laminar scan --include-paid
 uv run laminar items list
+uv run laminar items export items.yaml
+uv run laminar items import items.yaml
 ```
 
 ## Code Layout
@@ -56,6 +60,8 @@ uv run laminar items list
 ## Current Behavior Expectations
 
 - Blog ingestion is RSS/Atom-style feed ingestion.
+- `laminar source export/import` round-trip source definitions through YAML.
+- `laminar items export/import` round-trip stored items through YAML.
 - YouTube items should include transcript text when captions are available.
 - X ingestion currently assumes `xurl` or another configured command returns JSON in the expected shape.
 - X sources are treated as paid/metered by default, including legacy rows loaded from SQLite.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,8 +64,8 @@ uv run laminar items import items.yaml
 - `laminar items export/import` round-trip stored items through YAML.
 - YouTube items should include transcript text when captions are available.
 - X ingestion currently assumes `xurl` or another configured command returns JSON in the expected shape.
-- X sources are treated as paid/metered by default, including legacy rows loaded from SQLite.
-- Sources can also be explicitly marked as paid via `--costs-money`.
+- X sources are treated as paid by default, including legacy rows loaded from SQLite.
+- Sources can also be explicitly marked as paid via `--paid`.
 - Dedupe is based on canonical URL first, then `(source_id, external_id)`.
 - Search is text-based over title, excerpt, and stored content text.
 - `laminar scan` skips paid sources by default unless `--include-paid` is passed.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ uv run laminar stats
 
 YouTube sources now use the official YouTube Data API instead of the public XML feed. Set `YOUTUBE_API_KEY` in your environment before adding or scanning YouTube sources. Watch URLs, `/channel/...`, `@handle`, `/user/...`, and legacy `feeds/videos.xml?channel_id=...` URLs are accepted. By default Laminar fetches the latest 5 videos per YouTube scan; override that with `--num-items` when adding the source. During scans, Laminar fetches YouTube uploads one at a time, attempts the transcript immediately, and stops advancing to older videos after the first transcript failure. It also reports transcript failures inline and distinguishes missing transcripts from rate limits and other fetch failures in stored item metadata.
 
-X sources are treated as paid by default, including when the type is inferred from an X URL. Use `--paid` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
+X sources are treated as paid by default, including when the type is inferred from an X URL. Use `--paid` for any other source backed by a paid API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
 
 For X sources, Laminar resolves the source URL through `xurl` automatically. X list browser URLs like `https://x.com/i/lists/...` are detected automatically and translated into the corresponding list-tweets API request before invoking `xurl`; other X URLs are treated as user sources.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Laminar
 
-> Never look at an algorithmic feed that you don't control again
+> Never look at an algorithmic feed that you _don't control_ ever again
 
 ![Laminar logo](assets/laminar-logo.png)
 
@@ -33,7 +33,7 @@ Add sources through the CLI:
 
 ```bash
 uv run laminar source add --name "SCMP News" https://www.scmp.com/rss/4/feed/
-uv run laminar source add --name "Example Channel" "https://www.youtube.com/feeds/videos.xml?channel_id=..." --transcript-language en
+uv run laminar source add --name "Example Channel" "https://www.youtube.com/watch?v=USWIF6v6xgY" --transcript-language en --num-items 5
 uv run laminar source add --name "Example on X" https://x.com/example
 uv run laminar source add --name "AI Researchers" https://x.com/i/lists/1234567890
 uv run laminar source show SOURCE_ID
@@ -47,7 +47,9 @@ uv run laminar scan --source youtube
 uv run laminar stats
 ```
 
-`laminar source add` always takes the source URL as a positional argument. When `--type` is omitted, Laminar infers X URLs as `x`, YouTube feed URLs as `youtube`, and treats everything else as `feed`. If you pass `--type`, that explicit value wins. For now, the user-facing CLI only exposes `feed`, `youtube`, and `x`. Every option in `laminar source add --help` includes a description so the command is easier to discover.
+`laminar source add` always takes the source URL as a positional argument. When `--type` is omitted, Laminar infers X URLs as `x`, YouTube URLs as `youtube`, and treats everything else as `feed`. If you pass `--type`, that explicit value wins. For now, the user-facing CLI only exposes `feed`, `youtube`, and `x`. Every option in `laminar source add --help` includes a description so the command is easier to discover.
+
+YouTube sources now use the official YouTube Data API instead of the public XML feed. Set `YOUTUBE_API_KEY` in your environment before adding or scanning YouTube sources. Watch URLs, `/channel/...`, `@handle`, `/user/...`, and legacy `feeds/videos.xml?channel_id=...` URLs are accepted. By default Laminar fetches the latest 5 videos per YouTube scan; override that with `--num-items` when adding the source. During scans, Laminar fetches YouTube uploads one at a time, attempts the transcript immediately, and stops advancing to older videos after the first transcript failure. It also reports transcript failures inline and distinguishes missing transcripts from rate limits and other fetch failures in stored item metadata.
 
 X sources are treated as paid by default, including when the type is inferred from an X URL. Use `--paid` for any other source backed by a paid or metered API. Paid sources are skipped by default during `scan`; pass `--include-paid` when you want to scan them.
 
@@ -61,6 +63,6 @@ For X sources, Laminar resolves the source URL through `xurl` automatically. X l
 
 Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 
-`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed and YouTube scans assume reverse-chronological ordering and stop once they reach older entries; X scans invoke `xurl` for the configured source URL and then filter out items at or before the last successful scan time locally.
+`laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed scans assume reverse-chronological ordering and stop once they reach older entries; YouTube scans walk the channel uploads playlist via the YouTube Data API and stop once they reach older entries; X scans invoke `xurl` for the configured source URL and then filter out items at or before the last successful scan time locally.
 
 `laminar stats` shows an overview of total sources and items, plus approximate logical item size derived from the text stored in SQLite. It also groups counts and size by source kind and by individual source.

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ For X sources, Laminar resolves the source URL through `xurl` automatically. X l
 
 `laminar source show` prints the stored details for a single source as JSON, including its config fields, last successful scan timestamp, item count, and logical item size.
 
-`laminar source export PATH` writes all stored sources to a YAML file, preserving source IDs, metadata, transcript language preferences, and the last successful scan timestamp. `laminar source import PATH` reads that YAML back in and upserts sources by source ID.
+`laminar source export [PATH]` writes all stored sources to YAML, preserving source IDs, metadata, transcript language preferences, and the last successful scan timestamp. If `PATH` is omitted, Laminar writes the YAML to stdout so you can pipe it. `laminar source import PATH` reads that YAML back in and upserts sources by source ID.
 
 `laminar items remove` deletes a single stored item and its associated stored content. Like `items show`, it accepts an exact item ID, a unique item ID prefix, or a unique title.
 
-`laminar items export PATH` writes stored items to YAML. You can filter with `--source` and `--type`. `laminar items import PATH` reads that YAML back in and upserts items using the existing canonical URL and `(source_id, external_id)` dedupe rules, while preserving exported item IDs for new rows. Importing items does not create source definitions; if an item references a source ID that is not present in the `sources` table, Laminar keeps the item and reports that source as `[missing source]` in stats until you import or add the source separately.
+`laminar items export [PATH]` writes stored items to YAML. If `PATH` is omitted, Laminar writes the YAML to stdout so you can pipe it. You can filter with `--source` and `--type`. `laminar items import PATH` reads that YAML back in and upserts items using the existing canonical URL and `(source_id, external_id)` dedupe rules, while preserving exported item IDs for new rows. Importing items does not create source definitions; if an item references a source ID that is not present in the `sources` table, Laminar keeps the item and reports that source as `[missing source]` in stats until you import or add the source separately.
 
 Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 

--- a/README.md
+++ b/README.md
@@ -37,13 +37,19 @@ uv run laminar source add --name "Example Channel" "https://www.youtube.com/watc
 uv run laminar source add --name "Example on X" https://x.com/example
 uv run laminar source add --name "AI Researchers" https://x.com/i/lists/1234567890
 uv run laminar source show SOURCE_ID
+uv run laminar source export sources.yaml
+uv run laminar source import sources.yaml
 uv run laminar source remove SOURCE_ID
 uv run laminar source remove --recursive SOURCE_ID
+uv run laminar items export items.yaml
+uv run laminar items import items.yaml
 uv run laminar items remove ITEM_ID
 uv run laminar source list
 uv run laminar scan --include-paid
 uv run laminar scan -i -v
 uv run laminar scan --source youtube
+uv run laminar scans list
+uv run laminar scans show 1
 uv run laminar stats
 ```
 
@@ -59,10 +65,16 @@ For X sources, Laminar resolves the source URL through `xurl` automatically. X l
 
 `laminar source show` prints the stored details for a single source as JSON, including its config fields, last successful scan timestamp, item count, and logical item size.
 
+`laminar source export PATH` writes all stored sources to a YAML file, preserving source IDs, metadata, transcript language preferences, and the last successful scan timestamp. `laminar source import PATH` reads that YAML back in and upserts sources by source ID.
+
 `laminar items remove` deletes a single stored item and its associated stored content. Like `items show`, it accepts an exact item ID, a unique item ID prefix, or a unique title.
+
+`laminar items export PATH` writes stored items to YAML. You can filter with `--source` and `--type`. `laminar items import PATH` reads that YAML back in and upserts items using the existing canonical URL and `(source_id, external_id)` dedupe rules, while preserving exported item IDs for new rows. Importing items does not create source definitions; if an item references a source ID that is not present in the `sources` table, Laminar keeps the item and reports that source as `[missing source]` in stats until you import or add the source separately.
 
 Pass `-v` or `--verbose` to `laminar scan` when you want detailed progress logging, including the active incremental cutoff and when older entries are skipped because they are at or before that watermark. Use `-i` or `--include-paid` to include paid sources.
 
 `laminar scan` stores the last successful scan time for each source and uses it as an incremental cutoff on later runs. Feed scans assume reverse-chronological ordering and stop once they reach older entries; YouTube scans walk the channel uploads playlist via the YouTube Data API and stop once they reach older entries; X scans invoke `xurl` for the configured source URL and then filter out items at or before the last successful scan time locally.
+
+Laminar also stores a durable scan history for each top-level `scan` invocation. Each run records the selected filters, the sources it actually considered, whether each source was scanned, skipped, or failed, and the item-level outcomes (`new` vs `existing`) returned by adapters for scanned sources. Use `laminar scans list` for a summary view and `laminar scans show RUN_ID` for JSON detail.
 
 `laminar stats` shows an overview of total sources and items, plus approximate logical item size derived from the text stored in SQLite. It also groups counts and size by source kind and by individual source.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 requires-python = ">=3.11"
 dependencies = [
+    "google-api-python-client>=2.194.0",
     "PyYAML>=6,<7",
     "rich>=14.1,<15",
     "youtube-transcript-api>=1.2.4,<2",

--- a/skills/operate-laminar/SKILL.md
+++ b/skills/operate-laminar/SKILL.md
@@ -34,7 +34,7 @@ Use these commands for inspection and cleanup:
 
 - `uv run laminar source list`
 - `uv run laminar source show SOURCE_ID`
-- `uv run laminar source export PATH`
+- `uv run laminar source export [PATH]`
 - `uv run laminar source import PATH`
 - `uv run laminar source remove SOURCE_ID`
 - `uv run laminar source remove --recursive SOURCE_ID`
@@ -43,7 +43,7 @@ Prefer the CLI over manual database edits when changing source state.
 
 Source import/export expectations:
 
-- `laminar source export` writes all stored sources to YAML, including source IDs, metadata, transcript languages, and `last_successful_scan_at`.
+- `laminar source export` writes all stored sources to YAML, including source IDs, metadata, transcript languages, and `last_successful_scan_at`. When `PATH` is omitted, it writes YAML to stdout.
 - `laminar source import` upserts sources by source ID.
 
 ## Scan And Retrieval Workflows
@@ -61,9 +61,9 @@ Use these commands to inspect what Laminar stored:
 - `uv run laminar items list --limit 20`
 - `uv run laminar items list --source SOURCE_ID`
 - `uv run laminar items show ITEM_ID`
-- `uv run laminar items export PATH`
-- `uv run laminar items export PATH --source SOURCE_ID`
-- `uv run laminar items export PATH --type video`
+- `uv run laminar items export [PATH]`
+- `uv run laminar items export [PATH] --source SOURCE_ID`
+- `uv run laminar items export [PATH] --type video`
 - `uv run laminar items import PATH`
 - `uv run laminar items remove ITEM_ID`
 - `uv run laminar search "query terms"`
@@ -73,7 +73,7 @@ Search is text-based over title, excerpt, and stored content text. YouTube items
 
 Item import/export expectations:
 
-- `laminar items export` writes stored items to YAML and supports `--source` and `--type` filters.
+- `laminar items export` writes stored items to YAML and supports `--source` and `--type` filters. When `PATH` is omitted, it writes YAML to stdout.
 - `laminar items import` upserts items using canonical URL first, then `(source_id, external_id)`.
 - Importing items does not create source definitions. If imported items reference missing source IDs, Laminar keeps the items and reports those sources as `[missing source]` in stats until the sources are added or imported separately.
 

--- a/skills/operate-laminar/SKILL.md
+++ b/skills/operate-laminar/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: operate-laminar
+description: Operate the Laminar local-first CLI for source management, scans, search, stats, and ingestion debugging. Use when Codex needs to add, validate, show, list, or remove Laminar sources; run `laminar scan`; inspect stored items; troubleshoot feed, YouTube, or X ingestion; or make Laminar code changes in this repository while preserving the CLI/config/adapter/repository split.
+---
+
+# Operate Laminar
+
+Use Laminar through its CLI first. Prefer `uv run laminar ...` for user-facing workflows and use direct Python/module inspection only when debugging implementation details or writing tests.
+
+Laminar is local-first and SQLite-backed. By default it uses `~/.laminar/config.yaml` and `~/.laminar/laminar.db`, so for tests and reproductions prefer explicit `--config` and `--db` paths to avoid touching a real user state directory unless the task is explicitly about the default install.
+
+## Quick Start
+
+- Run setup with `uv sync` if the environment is not ready.
+- Validate config and stored sources with `uv run laminar source validate`.
+- Run scans with `uv run laminar scan` or `uv run laminar scan --include-paid`.
+- Inspect results with `uv run laminar items list`, `uv run laminar search <query>`, and `uv run laminar stats`.
+- Run `uv run pytest` after behavior changes. Update `README.md` and tests when defaults or user-facing behavior change.
+
+## Source Workflows
+
+Use `laminar source add --name <NAME> URL` as the normal way to create sources.
+
+- `--type` accepts `feed`, `youtube`, or `x`. If omitted, Laminar infers X URLs as `x`, YouTube feed URLs as `youtube`, and everything else as a feed source.
+- The source URL is positional. Do not rewrite it into a named flag.
+- For YouTube, use repeatable `--transcript-language` flags when transcript preference matters.
+- X sources are treated as paid by default, including inferred X URLs. Other metered sources should be marked with `--paid`.
+- Use `--disable` to save a source without scanning it yet.
+- Use repeatable `--metadata KEY=VALUE` to preserve extra source metadata.
+
+Use these commands for inspection and cleanup:
+
+- `uv run laminar source list`
+- `uv run laminar source show SOURCE_ID`
+- `uv run laminar source remove SOURCE_ID`
+- `uv run laminar source remove --recursive SOURCE_ID`
+
+Prefer the CLI over manual database edits when changing source state.
+
+## Scan And Retrieval Workflows
+
+Use `laminar scan` as the primary ingest entry point.
+
+- Paid sources are skipped by default. Pass `--include-paid` when the task requires scanning them.
+- Scans should continue after per-source failures and report status per source.
+- Use `-v` or `--verbose` when debugging incremental cutoffs or skipped entries.
+- Use `--source feed`, `--source youtube`, or `--source x` to limit scan kinds.
+- Pass source IDs after `scan` to target specific configured sources.
+
+Use these commands to inspect what Laminar stored:
+
+- `uv run laminar items list --limit 20`
+- `uv run laminar items list --source SOURCE_ID`
+- `uv run laminar items show ITEM_ID`
+- `uv run laminar items remove ITEM_ID`
+- `uv run laminar search "query terms"`
+- `uv run laminar stats`
+
+Search is text-based over title, excerpt, and stored content text. YouTube items should include transcript text when captions are available.
+
+## Implementation Guardrails
+
+Keep Laminar's layering intact when editing code:
+
+- `src/laminar/cli.py`: argument parsing and command dispatch
+- `src/laminar/config.py`: config loading and validation
+- `src/laminar/adapters.py`: source-kind-specific ingestion behavior
+- `src/laminar/youtube.py`: transcript helpers
+- `src/laminar/repository.py`: SQLite schema and persistence
+
+Preserve these expectations unless the user asks to change them:
+
+- Dedupe uses canonical URL first, then `(source_id, external_id)`.
+- X ingestion relies on `xurl` or a compatible command returning the expected JSON shape.
+- X sources, including legacy SQLite rows, are treated as paid by default.
+- `laminar scan` skips paid sources unless `--include-paid` is set.
+- Blog ingestion is RSS/Atom style feed ingestion.
+- YouTube live feed support is known to be imperfect.
+
+Avoid hardcoding user-specific paths other than the default `~/.laminar` state location.
+
+## Validation
+
+After code or behavior changes, run the narrowest useful test plus the full suite when practical.
+
+- Start with targeted tests such as `uv run pytest tests/test_cli.py` or another affected file.
+- Run `uv run pytest` before wrapping up if the change touches user-visible behavior, persistence, or adapters.
+- If you changed CLI defaults, help text, or behavior described to users, update `README.md` in the same change.
+
+When reproducing CLI behavior in tests, prefer temporary config and database paths instead of the default `~/.laminar` state.

--- a/skills/operate-laminar/SKILL.md
+++ b/skills/operate-laminar/SKILL.md
@@ -26,7 +26,7 @@ Use `laminar source add --name <NAME> URL` as the normal way to create sources.
 - `--type` accepts `feed`, `youtube`, or `x`. If omitted, Laminar infers X URLs as `x`, YouTube feed URLs as `youtube`, and everything else as a feed source.
 - The source URL is positional. Do not rewrite it into a named flag.
 - For YouTube, use repeatable `--transcript-language` flags when transcript preference matters.
-- X sources are treated as paid by default, including inferred X URLs. Other metered sources should be marked with `--paid`.
+- X sources are treated as paid by default, including inferred X URLs. Other paid sources should be marked with `--paid`.
 - Use `--disable` to save a source without scanning it yet.
 - Use repeatable `--metadata KEY=VALUE` to preserve extra source metadata.
 

--- a/skills/operate-laminar/SKILL.md
+++ b/skills/operate-laminar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: operate-laminar
-description: Operate the Laminar local-first CLI for source management, scans, search, stats, and ingestion debugging. Use when Codex needs to add, validate, show, list, or remove Laminar sources; run `laminar scan`; inspect stored items; troubleshoot feed, YouTube, or X ingestion; or make Laminar code changes in this repository while preserving the CLI/config/adapter/repository split.
+description: Operate the Laminar local-first CLI for source management, source and item import/export, scans, search, stats, and ingestion debugging. Use when Codex needs to add, validate, show, list, import, export, or remove Laminar sources; import, export, inspect, or remove stored items; run `laminar scan`; troubleshoot feed, YouTube, or X ingestion; or make Laminar code changes in this repository while preserving the CLI/config/adapter/repository split.
 ---
 
 # Operate Laminar
@@ -13,7 +13,9 @@ Laminar is local-first and SQLite-backed. By default it uses `~/.laminar/config.
 
 - Run setup with `uv sync` if the environment is not ready.
 - Validate config and stored sources with `uv run laminar source validate`.
+- Export or import sources with `uv run laminar source export sources.yaml` and `uv run laminar source import sources.yaml`.
 - Run scans with `uv run laminar scan` or `uv run laminar scan --include-paid`.
+- Export or import items with `uv run laminar items export items.yaml` and `uv run laminar items import items.yaml`.
 - Inspect results with `uv run laminar items list`, `uv run laminar search <query>`, and `uv run laminar stats`.
 - Run `uv run pytest` after behavior changes. Update `README.md` and tests when defaults or user-facing behavior change.
 
@@ -32,10 +34,17 @@ Use these commands for inspection and cleanup:
 
 - `uv run laminar source list`
 - `uv run laminar source show SOURCE_ID`
+- `uv run laminar source export PATH`
+- `uv run laminar source import PATH`
 - `uv run laminar source remove SOURCE_ID`
 - `uv run laminar source remove --recursive SOURCE_ID`
 
 Prefer the CLI over manual database edits when changing source state.
+
+Source import/export expectations:
+
+- `laminar source export` writes all stored sources to YAML, including source IDs, metadata, transcript languages, and `last_successful_scan_at`.
+- `laminar source import` upserts sources by source ID.
 
 ## Scan And Retrieval Workflows
 
@@ -52,11 +61,21 @@ Use these commands to inspect what Laminar stored:
 - `uv run laminar items list --limit 20`
 - `uv run laminar items list --source SOURCE_ID`
 - `uv run laminar items show ITEM_ID`
+- `uv run laminar items export PATH`
+- `uv run laminar items export PATH --source SOURCE_ID`
+- `uv run laminar items export PATH --type video`
+- `uv run laminar items import PATH`
 - `uv run laminar items remove ITEM_ID`
 - `uv run laminar search "query terms"`
 - `uv run laminar stats`
 
 Search is text-based over title, excerpt, and stored content text. YouTube items should include transcript text when captions are available.
+
+Item import/export expectations:
+
+- `laminar items export` writes stored items to YAML and supports `--source` and `--type` filters.
+- `laminar items import` upserts items using canonical URL first, then `(source_id, external_id)`.
+- Importing items does not create source definitions. If imported items reference missing source IDs, Laminar keeps the items and reports those sources as `[missing source]` in stats until the sources are added or imported separately.
 
 ## Implementation Guardrails
 

--- a/src/laminar/adapters.py
+++ b/src/laminar/adapters.py
@@ -8,12 +8,13 @@ from urllib.parse import parse_qsl, urlencode, urlparse
 from xml.etree import ElementTree
 
 from laminar.fetch import fetch_text
-from laminar.models import NormalizedItem, SourceConfig
+from laminar.models import ContentStatus, NormalizedItem, SourceConfig
 from laminar.youtube import (
     TranscriptUnavailable,
     extract_video_id,
     fetch_transcript,
 )
+from laminar import youtube_api
 
 
 class Adapter(Protocol):
@@ -132,6 +133,85 @@ class YouTubeAdapter:
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
+        uploads_playlist_id = _youtube_uploads_playlist_id(source)
+        if uploads_playlist_id is not None:
+            return self._scan_api(
+                source,
+                uploads_playlist_id,
+                since=since,
+                verbose=verbose,
+            )
+        return self._scan_feed(source, since=since, verbose=verbose)
+
+    def _scan_api(
+        self,
+        source: SourceConfig,
+        uploads_playlist_id: str,
+        *,
+        since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
+    ) -> list[NormalizedItem]:
+        items: list[NormalizedItem] = []
+        num_items = _youtube_num_items(source)
+        for upload in youtube_api.iter_uploads(
+            uploads_playlist_id,
+            limit=num_items,
+            page_size=1,
+        ):
+            if since and upload.published_at and upload.published_at <= since:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: stopping youtube scan at {_display_dt(upload.published_at)} because it is at or before cutoff {_display_dt(since)}",
+                )
+                break
+            transcript_payload = _fetch_transcript_payload(
+                source,
+                upload.video_id,
+                verbose=verbose,
+            )
+            items.append(
+                NormalizedItem(
+                    source_id=source.id,
+                    item_type="video",
+                    external_id=upload.video_id,
+                    canonical_url=upload.canonical_url,
+                    title=upload.title,
+                    author=upload.channel_title or source.name,
+                    published_at=upload.published_at,
+                    excerpt=upload.description or upload.title,
+                    content_text=transcript_payload["content_text"],
+                    content_status=transcript_payload["content_status"],
+                    content_language=transcript_payload["content_language"],
+                    content_source=transcript_payload["content_source"],
+                    raw_payload={
+                        "video_id": upload.video_id,
+                        "channel_id": source.metadata.get("channel_id"),
+                        "uploads_playlist_id": uploads_playlist_id,
+                        "channel_title": upload.channel_title,
+                        "transcript_is_generated": transcript_payload[
+                            "transcript_is_generated"
+                        ],
+                        "transcript_segments": transcript_payload[
+                            "transcript_segments"
+                        ],
+                    },
+                )
+            )
+            if transcript_payload["content_status"] != ContentStatus.AVAILABLE:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: stopping youtube scan after transcript {transcript_payload['content_status'].value} for {upload.video_id}",
+                )
+                break
+        return items
+
+    def _scan_feed(
+        self,
+        source: SourceConfig,
+        *,
+        since: datetime | None = None,
+        verbose: Callable[[str], None] | None = None,
+    ) -> list[NormalizedItem]:
         xml_text = fetch_text(source.feed_url or "")
         root = ElementTree.fromstring(xml_text)
         ns = {
@@ -140,7 +220,10 @@ class YouTubeAdapter:
         }
         channel_title = _find_text(root, "./atom:title", ns)
         items: list[NormalizedItem] = []
+        num_items = _youtube_num_items(source)
         for entry in root.findall("./atom:entry", ns):
+            if len(items) >= num_items:
+                break
             published_at = _parse_dt(_find_text(entry, "./atom:published", ns))
             if since and published_at and published_at <= since:
                 _verbose_log(
@@ -154,43 +237,11 @@ class YouTubeAdapter:
             video_id = _find_text(entry, "./yt:videoId", ns) or extract_video_id(
                 video_url
             )
-            transcript_text = None
-            transcript_status = "missing"
-            transcript_language = None
-            transcript_source = None
-            transcript_segments: list[dict[str, object]] = []
-            transcript_is_generated = None
-            if video_url and video_id:
-                try:
-                    transcript = fetch_transcript(
-                        video_id,
-                        source.transcript_languages,
-                    )
-                    transcript_text = transcript.text
-                    transcript_language = transcript.language_code
-                    transcript_source = transcript.source
-                    transcript_is_generated = transcript.is_generated
-                    transcript_segments = [
-                        {
-                            "text": segment.text,
-                            "start": segment.start,
-                            "duration": segment.duration,
-                            "timestamp": segment.timestamp,
-                        }
-                        for segment in transcript.segments
-                    ]
-                    transcript_status = "available"
-                    _verbose_log(
-                        verbose,
-                        f"{source.id}: transcript available for {video_id} in {transcript_language or 'unknown language'} via {transcript_source or 'unknown source'}",
-                    )
-                except TranscriptUnavailable:
-                    transcript_status = "missing"
-                    _verbose_log(
-                        verbose,
-                        f"{source.id}: transcript missing for {video_id}",
-                    )
-
+            transcript_payload = _fetch_transcript_payload(
+                source,
+                video_id,
+                verbose=verbose,
+            )
             items.append(
                 NormalizedItem(
                     source_id=source.id,
@@ -203,19 +254,108 @@ class YouTubeAdapter:
                     published_at=published_at,
                     excerpt=_find_text(entry, "./atom:group/atom:description", ns)
                     or _find_text(entry, "./atom:title", ns),
-                    content_text=transcript_text,
-                    content_status=transcript_status,
-                    content_language=transcript_language,
-                    content_source=transcript_source,
+                    content_text=transcript_payload["content_text"],
+                    content_status=transcript_payload["content_status"],
+                    content_language=transcript_payload["content_language"],
+                    content_source=transcript_payload["content_source"],
                     raw_payload={
                         "video_id": video_id,
                         "channel_title": channel_title,
-                        "transcript_is_generated": transcript_is_generated,
-                        "transcript_segments": transcript_segments,
+                        "transcript_is_generated": transcript_payload[
+                            "transcript_is_generated"
+                        ],
+                        "transcript_segments": transcript_payload[
+                            "transcript_segments"
+                        ],
                     },
                 )
             )
+            if transcript_payload["content_status"] != ContentStatus.AVAILABLE:
+                _verbose_log(
+                    verbose,
+                    f"{source.id}: stopping youtube scan after transcript {transcript_payload['content_status'].value} for {video_id or '(unknown video)'}",
+                )
+                break
         return items
+
+
+def _youtube_num_items(source: SourceConfig) -> int:
+    num_items = source.metadata.get("num_items")
+    if isinstance(num_items, int) and num_items > 0:
+        return num_items
+    if isinstance(num_items, str):
+        try:
+            parsed = int(num_items)
+        except ValueError:
+            parsed = 0
+        if parsed > 0:
+            return parsed
+    return 5
+
+
+def _youtube_uploads_playlist_id(source: SourceConfig) -> str | None:
+    uploads_playlist_id = source.metadata.get("uploads_playlist_id")
+    if isinstance(uploads_playlist_id, str) and uploads_playlist_id.strip():
+        return uploads_playlist_id.strip()
+
+    channel_id = source.metadata.get("channel_id")
+    if isinstance(channel_id, str) and channel_id.strip():
+        return youtube_api.get_channel(channel_id.strip()).uploads_playlist_id
+
+    if source.feed_url and youtube_api.looks_like_youtube_url(source.feed_url):
+        return youtube_api.resolve_channel_from_url(source.feed_url).uploads_playlist_id
+
+    return None
+
+
+def _fetch_transcript_payload(
+    source: SourceConfig,
+    video_id: str | None,
+    *,
+    verbose: Callable[[str], None] | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "content_text": None,
+        "content_status": ContentStatus.FETCH_FAILED,
+        "content_language": None,
+        "content_source": None,
+        "transcript_is_generated": None,
+        "transcript_segments": [],
+    }
+    if not video_id:
+        return payload
+
+    try:
+        transcript = fetch_transcript(
+            video_id,
+            source.transcript_languages,
+        )
+        payload["content_text"] = transcript.text
+        payload["content_language"] = transcript.language_code
+        payload["content_source"] = transcript.source
+        payload["transcript_is_generated"] = transcript.is_generated
+        payload["transcript_segments"] = [
+            {
+                "text": segment.text,
+                "start": segment.start,
+                "duration": segment.duration,
+                "timestamp": segment.timestamp,
+            }
+            for segment in transcript.segments
+        ]
+        payload["content_status"] = ContentStatus.AVAILABLE
+        _verbose_log(
+            verbose,
+            f"{source.id}: transcript available for {video_id} in {transcript.language_code or 'unknown language'} via {transcript.source or 'unknown source'}",
+        )
+    except TranscriptUnavailable as exc:
+        payload["content_status"] = exc.content_status
+        _verbose_log(
+            verbose,
+            f"{source.id}: transcript {exc.content_status.value} for {video_id}",
+        )
+
+    return payload
 
 
 class XAdapter:

--- a/src/laminar/adapters.py
+++ b/src/laminar/adapters.py
@@ -24,6 +24,7 @@ class Adapter(Protocol):
         *,
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]: ...
 
 
@@ -34,6 +35,7 @@ class FeedAdapter:
         *,
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         xml_text = fetch_text(source.feed_url or "")
         root = ElementTree.fromstring(xml_text)
@@ -132,6 +134,7 @@ class YouTubeAdapter:
         *,
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         uploads_playlist_id = _youtube_uploads_playlist_id(source)
         if uploads_playlist_id is not None:
@@ -140,8 +143,9 @@ class YouTubeAdapter:
                 uploads_playlist_id,
                 since=since,
                 verbose=verbose,
+                progress=progress,
             )
-        return self._scan_feed(source, since=since, verbose=verbose)
+        return self._scan_feed(source, since=since, verbose=verbose, progress=progress)
 
     def _scan_api(
         self,
@@ -150,6 +154,7 @@ class YouTubeAdapter:
         *,
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         items: list[NormalizedItem] = []
         num_items = _youtube_num_items(source)
@@ -164,10 +169,15 @@ class YouTubeAdapter:
                     f"{source.id}: stopping youtube scan at {_display_dt(upload.published_at)} because it is at or before cutoff {_display_dt(since)}",
                 )
                 break
+            _progress_log(
+                progress,
+                f"{source.id}: discovered {upload.title} ({upload.video_id})",
+            )
             transcript_payload = _fetch_transcript_payload(
                 source,
                 upload.video_id,
                 verbose=verbose,
+                progress=progress,
             )
             items.append(
                 NormalizedItem(
@@ -211,6 +221,7 @@ class YouTubeAdapter:
         *,
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         xml_text = fetch_text(source.feed_url or "")
         root = ElementTree.fromstring(xml_text)
@@ -237,10 +248,16 @@ class YouTubeAdapter:
             video_id = _find_text(entry, "./yt:videoId", ns) or extract_video_id(
                 video_url
             )
+            title = _find_text(entry, "./atom:title", ns) or "(untitled video)"
+            _progress_log(
+                progress,
+                f"{source.id}: discovered {title} ({video_id or 'unknown video'})",
+            )
             transcript_payload = _fetch_transcript_payload(
                 source,
                 video_id,
                 verbose=verbose,
+                progress=progress,
             )
             items.append(
                 NormalizedItem(
@@ -248,7 +265,7 @@ class YouTubeAdapter:
                     item_type="video",
                     external_id=video_id,
                     canonical_url=video_url,
-                    title=_find_text(entry, "./atom:title", ns) or "(untitled video)",
+                    title=title,
                     author=_find_text(entry, "./atom:author/atom:name", ns)
                     or channel_title,
                     published_at=published_at,
@@ -313,6 +330,7 @@ def _fetch_transcript_payload(
     video_id: str | None,
     *,
     verbose: Callable[[str], None] | None = None,
+    progress: Callable[[str], None] | None = None,
 ) -> dict[str, object]:
     payload: dict[str, object] = {
         "content_text": None,
@@ -348,11 +366,19 @@ def _fetch_transcript_payload(
             verbose,
             f"{source.id}: transcript available for {video_id} in {transcript.language_code or 'unknown language'} via {transcript.source or 'unknown source'}",
         )
+        _progress_log(
+            progress,
+            f"{source.id}: transcript found for {video_id}",
+        )
     except TranscriptUnavailable as exc:
         payload["content_status"] = exc.content_status
         _verbose_log(
             verbose,
             f"{source.id}: transcript {exc.content_status.value} for {video_id}",
+        )
+        _progress_log(
+            progress,
+            f"{source.id}: {_transcript_status_message(exc.content_status)} for {video_id}",
         )
 
     return payload
@@ -365,6 +391,7 @@ class XAdapter:
         *,
         since: datetime | None = None,
         verbose: Callable[[str], None] | None = None,
+        progress: Callable[[str], None] | None = None,
     ) -> list[NormalizedItem]:
         payload = _run_x_command(source, verbose=verbose)
         data = json.loads(payload)
@@ -641,6 +668,24 @@ def _verbose_log(
 ) -> None:
     if verbose is not None:
         verbose(message)
+
+
+def _progress_log(
+    progress: Callable[[str], None] | None,
+    message: str,
+) -> None:
+    if progress is not None:
+        progress(message)
+
+
+def _transcript_status_message(status: ContentStatus) -> str:
+    if status == ContentStatus.MISSING:
+        return "transcript missing"
+    if status == ContentStatus.RATE_LIMITED:
+        return "transcript rate-limited"
+    if status == ContentStatus.FETCH_FAILED:
+        return "transcript fetch failed"
+    return f"transcript {status.value}"
 
 
 def _display_dt(value: datetime | None) -> str:

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -70,7 +70,7 @@ def build_parser() -> argparse.ArgumentParser:
     show_source = source_subparsers.add_parser("show")
     show_source.add_argument("source_id")
     export_sources = source_subparsers.add_parser("export")
-    export_sources.add_argument("path")
+    export_sources.add_argument("path", nargs="?", default="-")
     import_sources = source_subparsers.add_parser("import")
     import_sources.add_argument("path")
 
@@ -185,7 +185,7 @@ def build_parser() -> argparse.ArgumentParser:
     items_remove = items_subparsers.add_parser("remove")
     items_remove.add_argument("item_id")
     items_export = items_subparsers.add_parser("export")
-    items_export.add_argument("path")
+    items_export.add_argument("path", nargs="?", default="-")
     items_export.add_argument("--source")
     items_export.add_argument("--type")
     items_import = items_subparsers.add_parser("import")
@@ -288,9 +288,10 @@ def _run_source(args: argparse.Namespace) -> int:
             "sources": [_source_to_export_dict(source) for source in repo.list_sources()],
         }
         _write_yaml_file(args.path, payload)
-        _console().print(
-            f"Exported {len(payload['sources'])} sources to {_display_path(args.path)}"
-        )
+        if args.path != "-":
+            _console().print(
+                f"Exported {len(payload['sources'])} sources to {_display_path(args.path)}"
+            )
         return 0
     if args.source_command == "import":
         payload = _load_yaml_file(args.path, label="Source import")
@@ -647,9 +648,10 @@ def _run_items(args: argparse.Namespace) -> int:
             "items": [_item_to_export_dict(item) for item in items],
         }
         _write_yaml_file(args.path, payload)
-        _console().print(
-            f"Exported {len(items)} items to {_display_path(args.path)}"
-        )
+        if args.path != "-":
+            _console().print(
+                f"Exported {len(items)} items to {_display_path(args.path)}"
+            )
         return 0
     if args.items_command == "import":
         payload = _load_yaml_file(args.path, label="Item import")

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -1,12 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import inspect
 import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 from uuid import uuid4
+
+import yaml
 
 from laminar.adapters import build_adapter
 from laminar.config import (
@@ -15,7 +18,7 @@ from laminar.config import (
     ensure_default_config,
     validate_source,
 )
-from laminar.models import ContentStatus, SourceConfig
+from laminar.models import ContentStatus, NormalizedItem, SourceConfig, StoredItem
 from laminar.repository import Repository
 from laminar import youtube_api
 from rich.console import Console
@@ -66,6 +69,10 @@ def build_parser() -> argparse.ArgumentParser:
     source_subparsers.add_parser("list")
     show_source = source_subparsers.add_parser("show")
     show_source.add_argument("source_id")
+    export_sources = source_subparsers.add_parser("export")
+    export_sources.add_argument("path")
+    import_sources = source_subparsers.add_parser("import")
+    import_sources.add_argument("path")
 
     add_source = source_subparsers.add_parser(
         "add",
@@ -153,6 +160,16 @@ def build_parser() -> argparse.ArgumentParser:
     )
     scan_parser.add_argument("source_ids", nargs="*")
 
+    scans_parser = subparsers.add_parser("scans")
+    scans_parser.set_defaults(command="scans")
+    scans_subparsers = scans_parser.add_subparsers(
+        dest="scans_command", required=True
+    )
+    scans_list = scans_subparsers.add_parser("list")
+    scans_list.add_argument("--limit", type=int, default=20)
+    scans_show = scans_subparsers.add_parser("show")
+    scans_show.add_argument("run_id", type=int)
+
     items_parser = subparsers.add_parser("items")
     items_parser.set_defaults(command="items")
     items_subparsers = items_parser.add_subparsers(dest="items_command", required=True)
@@ -167,6 +184,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     items_remove = items_subparsers.add_parser("remove")
     items_remove.add_argument("item_id")
+    items_export = items_subparsers.add_parser("export")
+    items_export.add_argument("path")
+    items_export.add_argument("--source")
+    items_export.add_argument("--type")
+    items_import = items_subparsers.add_parser("import")
+    items_import.add_argument("path")
 
     search_parser = subparsers.add_parser("search")
     search_parser.set_defaults(command="search")
@@ -185,10 +208,14 @@ def run(args: argparse.Namespace) -> int:
         command = "source"
     if command is None and hasattr(args, "items_command"):
         command = "items"
+    if command is None and hasattr(args, "scans_command"):
+        command = "scans"
     if command == "source":
         return _run_source(args)
     if command == "scan":
         return _run_scan(args)
+    if command == "scans":
+        return _run_scans(args)
     if command == "items":
         return _run_items(args)
     if command == "search":
@@ -255,6 +282,37 @@ def _run_source(args: argparse.Namespace) -> int:
         }
         _print_json(payload)
         return 0
+    if args.source_command == "export":
+        payload = {
+            "version": 1,
+            "sources": [_source_to_export_dict(source) for source in repo.list_sources()],
+        }
+        _write_yaml_file(args.path, payload)
+        _console().print(
+            f"Exported {len(payload['sources'])} sources to {_display_path(args.path)}"
+        )
+        return 0
+    if args.source_command == "import":
+        payload = _load_yaml_file(args.path, label="Source import")
+        raw_sources = payload.get("sources")
+        if not isinstance(raw_sources, list):
+            raise ConfigError("Source import file must contain a 'sources' list")
+        imported = 0
+        updated = 0
+        for index, entry in enumerate(raw_sources, start=1):
+            source = _parse_source_import_entry(entry, index=index)
+            validate_source(source)
+            if repo.get_source(source.id) is None:
+                imported += 1
+            else:
+                updated += 1
+            repo.upsert_source(source)
+            if source.last_successful_scan_at is not None:
+                repo.mark_source_scan_succeeded(source.id, source.last_successful_scan_at)
+        _console().print(
+            f"Imported {imported} new and {updated} existing sources from {_display_path(args.path)}"
+        )
+        return 0
 
     sources = repo.list_sources()
     if args.source_command == "validate":
@@ -307,13 +365,33 @@ def _run_scan(args: argparse.Namespace) -> int:
 
     total_seen = 0
     total_new = 0
+    total_existing = 0
     total_failed = 0
     total_skipped = 0
+    total_scanned = 0
+    run_id = repo.start_scan_run(
+        include_paid=args.include_paid,
+        selected_source_kinds=sorted(selected_kinds),
+        selected_source_ids=sorted(selected),
+    )
     verbose_print(
         f"scan configuration: {len(active_sources)} active sources, include_paid={args.include_paid}, selected_kinds={sorted(selected_kinds) or ['all']}, selected_ids={sorted(selected) or ['all']}"
     )
     for source in active_sources:
         if source.costs_money and not args.include_paid:
+            skipped_at = datetime.now(timezone.utc)
+            repo.record_scan_source(
+                run_id,
+                source=source,
+                status="skipped",
+                skip_reason="paid_not_included",
+                started_at=skipped_at,
+                finished_at=skipped_at,
+                cutoff_at=repo.last_successful_scan_at(source.id),
+                items_seen=0,
+                items_new=0,
+                items_existing=0,
+            )
             console.print(
                 f"Skipping {source.id} ({source.name}): paid source; rerun with --include-paid",
                 style="grey50",
@@ -321,7 +399,6 @@ def _run_scan(args: argparse.Namespace) -> int:
             total_skipped += 1
             continue
         scan_started_at = datetime.now(timezone.utc)
-        scan_id = repo.start_scan(source.id)
         console.print(f"Scanning {source.id} ({source.name})")
         if source.costs_money:
             console.print(
@@ -339,40 +416,199 @@ def _run_scan(args: argparse.Namespace) -> int:
                 )
             items = adapter.scan(
                 source,
-                since=previous_scan_at,
-                verbose=verbose_print,
+                **_scan_kwargs(
+                    adapter,
+                    since=previous_scan_at,
+                    verbose=verbose_print,
+                    progress=console.print if source.kind == "youtube" else None,
+                ),
             )
             verbose_print(
                 f"{source.id}: adapter returned {len(items)} items after cutoff filtering"
             )
             console.print(f"{source.id}: reachable", style="green")
             new_count = 0
+            existing_count = 0
+            scan_source_id = repo.record_scan_source(
+                run_id,
+                source=source,
+                status="success",
+                started_at=scan_started_at,
+                finished_at=None,
+                cutoff_at=previous_scan_at,
+                items_seen=0,
+                items_new=0,
+                items_existing=0,
+            )
             for item in items:
                 if repo.upsert_item(item):
                     new_count += 1
+                    item_result = "new"
                     console.print(f"{source.id}: new {item.title}", style="green")
                 else:
+                    existing_count += 1
+                    item_result = "existing"
                     console.print(f"{source.id}: existing {item.title}", style="cyan")
+                repo.record_scan_item(
+                    scan_source_id,
+                    item,
+                    result=item_result,
+                )
                 _report_item_content_status(console, source.id, item)
-            repo.finish_scan(
-                scan_id, status="success", items_seen=len(items), items_new=new_count
+            repo.update_scan_source(
+                scan_source_id,
+                status="success",
+                started_at=scan_started_at,
+                finished_at=datetime.now(timezone.utc),
+                cutoff_at=previous_scan_at,
+                items_seen=len(items),
+                items_new=new_count,
+                items_existing=existing_count,
             )
             repo.mark_source_scan_succeeded(source.id, scan_started_at)
             verbose_print(
                 f"{source.id}: marked successful scan watermark at {scan_started_at.isoformat()}"
             )
+            total_scanned += 1
             total_seen += len(items)
             total_new += new_count
+            total_existing += existing_count
         except Exception as exc:
-            repo.finish_scan(
-                scan_id, status="failed", items_seen=0, items_new=0, error=str(exc)
+            repo.record_scan_source(
+                run_id,
+                source=source,
+                status="failed",
+                started_at=scan_started_at,
+                finished_at=datetime.now(timezone.utc),
+                cutoff_at=repo.last_successful_scan_at(source.id),
+                items_seen=0,
+                items_new=0,
+                items_existing=0,
+                error=str(exc),
             )
+            total_scanned += 1
             total_failed += 1
             console.print(f"{source.id}: unreachable - {exc}", style="red")
             continue
+    if total_failed == 0:
+        run_status = "success"
+    elif total_scanned - total_failed > 0 or total_skipped > 0:
+        run_status = "partial_failure"
+    else:
+        run_status = "failed"
+    repo.finish_scan_run(
+        run_id,
+        status=run_status,
+        sources_considered=len(active_sources),
+        sources_scanned=total_scanned,
+        sources_skipped=total_skipped,
+        sources_failed=total_failed,
+        items_seen=total_seen,
+        items_new=total_new,
+        items_existing=total_existing,
+    )
     console.print(
         f"scan complete: {total_seen} items seen, {total_new} new, {total_failed} failed, {total_skipped} skipped"
     )
+    return 0
+
+
+def _run_scans(args: argparse.Namespace) -> int:
+    runtime = _load_runtime(args)
+    repo = Repository(runtime.database_path)
+    if args.scans_command == "list":
+        runs = repo.list_scan_runs(limit=args.limit)
+        table = Table(title="Scans")
+        table.add_column("Run", style="cyan", justify="right")
+        table.add_column("Started")
+        table.add_column("Status")
+        table.add_column("Filters")
+        table.add_column("Sources", justify="right")
+        table.add_column("Items", justify="right")
+        for run in runs:
+            table.add_row(
+                str(run.scan_run_id),
+                run.started_at.isoformat(),
+                run.status,
+                _format_scan_filters(run.selected_source_kinds, run.selected_source_ids, run.include_paid),
+                f"{run.sources_scanned}/{run.sources_considered}",
+                f"{run.items_seen} seen, {run.items_new} new, {run.items_existing} existing",
+            )
+        _console().print(table)
+        return 0
+
+    detail = repo.get_scan_run(args.run_id)
+    if detail is None:
+        print(f"Scan run {args.run_id} not found", file=sys.stderr)
+        return 1
+    payload = {
+        "run": {
+            "scan_run_id": detail.run.scan_run_id,
+            "started_at": detail.run.started_at.isoformat(),
+            "finished_at": (
+                detail.run.finished_at.isoformat()
+                if detail.run.finished_at is not None
+                else None
+            ),
+            "status": detail.run.status,
+            "include_paid": detail.run.include_paid,
+            "selected_source_kinds": detail.run.selected_source_kinds,
+            "selected_source_ids": detail.run.selected_source_ids,
+            "sources_considered": detail.run.sources_considered,
+            "sources_scanned": detail.run.sources_scanned,
+            "sources_skipped": detail.run.sources_skipped,
+            "sources_failed": detail.run.sources_failed,
+            "items_seen": detail.run.items_seen,
+            "items_new": detail.run.items_new,
+            "items_existing": detail.run.items_existing,
+            "error": detail.run.error,
+        },
+        "sources": [
+            {
+                "scan_source_id": source.scan_source_id,
+                "scan_run_id": source.scan_run_id,
+                "source_id": source.source_id,
+                "source_kind": source.source_kind,
+                "source_name": source.source_name,
+                "status": source.status,
+                "skip_reason": source.skip_reason,
+                "started_at": (
+                    source.started_at.isoformat() if source.started_at is not None else None
+                ),
+                "finished_at": (
+                    source.finished_at.isoformat() if source.finished_at is not None else None
+                ),
+                "cutoff_at": (
+                    source.cutoff_at.isoformat() if source.cutoff_at is not None else None
+                ),
+                "items_seen": source.items_seen,
+                "items_new": source.items_new,
+                "items_existing": source.items_existing,
+                "error": source.error,
+            }
+            for source in detail.sources
+        ],
+        "items": [
+            {
+                "scan_item_id": item.scan_item_id,
+                "scan_source_id": item.scan_source_id,
+                "source_id": item.source_id,
+                "item_id": item.item_id,
+                "external_id": item.external_id,
+                "canonical_url": item.canonical_url,
+                "title": item.title,
+                "published_at": (
+                    item.published_at.isoformat() if item.published_at is not None else None
+                ),
+                "result": item.result,
+                "content_status": str(item.content_status),
+                "content_source": item.content_source,
+                "failure_reason": item.failure_reason,
+            }
+            for item in detail.items
+        ],
+    }
+    _print_json(payload)
     return 0
 
 
@@ -400,6 +636,38 @@ def _run_items(args: argparse.Namespace) -> int:
             )
         _console().print(table)
         return 0
+    if args.items_command == "export":
+        items = repo.list_items(
+            source_id=args.source,
+            item_type=args.type,
+            limit=None,
+        )
+        payload = {
+            "version": 1,
+            "items": [_item_to_export_dict(item) for item in items],
+        }
+        _write_yaml_file(args.path, payload)
+        _console().print(
+            f"Exported {len(items)} items to {_display_path(args.path)}"
+        )
+        return 0
+    if args.items_command == "import":
+        payload = _load_yaml_file(args.path, label="Item import")
+        raw_items = payload.get("items")
+        if not isinstance(raw_items, list):
+            raise ConfigError("Item import file must contain an 'items' list")
+        imported = 0
+        updated = 0
+        for index, entry in enumerate(raw_items, start=1):
+            item = _parse_item_import_entry(entry, index=index)
+            if repo.upsert_item(item):
+                imported += 1
+            else:
+                updated += 1
+        _console().print(
+            f"Imported {imported} new and {updated} existing items from {_display_path(args.path)}"
+        )
+        return 0
 
     item = _resolve_item(repo, args.item_id)
     if item is None:
@@ -414,9 +682,11 @@ def _run_items(args: argparse.Namespace) -> int:
         "item_id": item.item_id,
         "source_id": item.source_id,
         "item_type": item.item_type,
+        "external_id": item.external_id,
         "title": item.title,
         "canonical_url": item.canonical_url,
         "published_at": item.published_at.isoformat() if item.published_at else None,
+        "retrieved_at": item.retrieved_at.isoformat(),
         "author": item.author,
         "excerpt": item.excerpt,
         "content_status": item.content_status,
@@ -506,6 +776,17 @@ def _format_bytes(size_bytes: int) -> str:
     return f"{size_bytes} B"
 
 
+def _format_scan_filters(
+    source_kinds: list[str],
+    source_ids: list[str],
+    include_paid: bool,
+) -> str:
+    kind_text = ",".join(source_kinds) if source_kinds else "all"
+    id_text = ",".join(source_ids) if source_ids else "all"
+    paid_text = "include-paid" if include_paid else "free-only"
+    return f"kinds={kind_text} ids={id_text} {paid_text}"
+
+
 def _report_item_content_status(
     console: Console,
     source_id: str,
@@ -523,6 +804,269 @@ def _report_item_content_status(
     else:
         message = "transcript fetch failed"
     console.print(f"{source_id}: {message} for {item.title}", style="yellow")
+
+
+def _scan_kwargs(
+    adapter: object,
+    *,
+    since: datetime | None,
+    verbose,
+    progress,
+) -> dict[str, object]:
+    kwargs: dict[str, object] = {
+        "since": since,
+        "verbose": verbose,
+    }
+    scan = getattr(adapter, "scan", None)
+    if callable(scan):
+        parameters = inspect.signature(scan).parameters
+        if "progress" in parameters:
+            kwargs["progress"] = progress
+    return kwargs
+
+
+def _source_to_export_dict(source: SourceConfig) -> dict[str, object]:
+    return {
+        "id": source.id,
+        "kind": source.kind,
+        "name": source.name,
+        "enabled": source.enabled,
+        "costs_money": source.costs_money,
+        "feed_url": source.feed_url,
+        "handle": source.handle,
+        "transcript_languages": list(source.transcript_languages),
+        "metadata": source.metadata,
+        "last_successful_scan_at": (
+            source.last_successful_scan_at.isoformat()
+            if source.last_successful_scan_at is not None
+            else None
+        ),
+    }
+
+
+def _item_to_export_dict(item: StoredItem) -> dict[str, object]:
+    return {
+        "item_id": item.item_id,
+        "source_id": item.source_id,
+        "item_type": item.item_type,
+        "external_id": item.external_id,
+        "canonical_url": item.canonical_url,
+        "title": item.title,
+        "author": item.author,
+        "published_at": item.published_at.isoformat() if item.published_at else None,
+        "retrieved_at": item.retrieved_at.isoformat(),
+        "excerpt": item.excerpt,
+        "content_text": item.content_text,
+        "content_status": str(item.content_status),
+        "content_language": item.content_language,
+        "content_source": item.content_source,
+        "raw_payload": item.raw_payload,
+    }
+
+
+def _parse_source_import_entry(entry: object, *, index: int) -> SourceConfig:
+    raw = _require_mapping(entry, label=f"Source entry {index}")
+    source_id = _require_non_empty_string(raw.get("id"), field="id", label=f"Source entry {index}")
+    kind = _require_non_empty_string(raw.get("kind"), field="kind", label=f"Source entry {index}")
+    name = _require_non_empty_string(raw.get("name"), field="name", label=f"Source entry {index}")
+    enabled = _coerce_bool(raw.get("enabled", True), field="enabled", label=f"Source entry {index}")
+    costs_money = _coerce_bool(raw.get("costs_money", False), field="costs_money", label=f"Source entry {index}")
+    feed_url = _coerce_optional_string(raw.get("feed_url"), field="feed_url", label=f"Source entry {index}")
+    handle = _coerce_optional_string(raw.get("handle"), field="handle", label=f"Source entry {index}")
+    transcript_languages = _coerce_string_list(
+        raw.get("transcript_languages", []),
+        field="transcript_languages",
+        label=f"Source entry {index}",
+    )
+    metadata = _coerce_object(raw.get("metadata", {}), field="metadata", label=f"Source entry {index}")
+    last_successful_scan_at = _coerce_optional_datetime(
+        raw.get("last_successful_scan_at"),
+        field="last_successful_scan_at",
+        label=f"Source entry {index}",
+    )
+    return SourceConfig(
+        id=source_id,
+        kind=kind,
+        name=name,
+        enabled=enabled,
+        costs_money=costs_money,
+        feed_url=feed_url,
+        handle=handle,
+        transcript_languages=transcript_languages,
+        metadata=metadata,
+        last_successful_scan_at=last_successful_scan_at,
+    )
+
+
+def _parse_item_import_entry(entry: object, *, index: int) -> NormalizedItem:
+    raw = _require_mapping(entry, label=f"Item entry {index}")
+    return NormalizedItem(
+        item_id=_require_non_empty_string(
+            raw.get("item_id"),
+            field="item_id",
+            label=f"Item entry {index}",
+        ),
+        source_id=_require_non_empty_string(
+            raw.get("source_id"),
+            field="source_id",
+            label=f"Item entry {index}",
+        ),
+        item_type=_require_non_empty_string(
+            raw.get("item_type"),
+            field="item_type",
+            label=f"Item entry {index}",
+        ),
+        external_id=_coerce_optional_string(
+            raw.get("external_id"),
+            field="external_id",
+            label=f"Item entry {index}",
+        ),
+        canonical_url=_coerce_optional_string(
+            raw.get("canonical_url"),
+            field="canonical_url",
+            label=f"Item entry {index}",
+        ),
+        title=_require_non_empty_string(
+            raw.get("title"),
+            field="title",
+            label=f"Item entry {index}",
+        ),
+        author=_coerce_optional_string(
+            raw.get("author"),
+            field="author",
+            label=f"Item entry {index}",
+        ),
+        published_at=_coerce_optional_datetime(
+            raw.get("published_at"),
+            field="published_at",
+            label=f"Item entry {index}",
+        ),
+        excerpt=_coerce_optional_string(
+            raw.get("excerpt"),
+            field="excerpt",
+            label=f"Item entry {index}",
+        ),
+        content_text=_coerce_optional_string(
+            raw.get("content_text"),
+            field="content_text",
+            label=f"Item entry {index}",
+        ),
+        content_status=ContentStatus.coerce(
+            _require_non_empty_string(
+                raw.get("content_status", ContentStatus.AVAILABLE),
+                field="content_status",
+                label=f"Item entry {index}",
+            )
+        ),
+        content_language=_coerce_optional_string(
+            raw.get("content_language"),
+            field="content_language",
+            label=f"Item entry {index}",
+        ),
+        content_source=_coerce_optional_string(
+            raw.get("content_source"),
+            field="content_source",
+            label=f"Item entry {index}",
+        ),
+        raw_payload=_coerce_object(
+            raw.get("raw_payload", {}),
+            field="raw_payload",
+            label=f"Item entry {index}",
+        ),
+        retrieved_at=_require_datetime(
+            raw.get("retrieved_at"),
+            field="retrieved_at",
+            label=f"Item entry {index}",
+        ),
+    )
+
+
+def _load_yaml_file(path: str, *, label: str) -> dict[str, object]:
+    resolved = _resolve_io_path(path)
+    try:
+        text = sys.stdin.read() if path == "-" else resolved.read_text()
+    except OSError as exc:
+        raise ConfigError(f"Could not read {label.lower()} file {resolved}: {exc}") from exc
+    try:
+        data = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        raise ConfigError(f"Invalid YAML in {resolved}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ConfigError(f"{label} file must be a YAML mapping")
+    return data
+
+
+def _write_yaml_file(path: str, payload: dict[str, object]) -> None:
+    rendered = yaml.safe_dump(payload, sort_keys=False, allow_unicode=False)
+    if path == "-":
+        sys.stdout.write(rendered)
+        return
+    resolved = _resolve_io_path(path)
+    resolved.parent.mkdir(parents=True, exist_ok=True)
+    resolved.write_text(rendered)
+
+
+def _resolve_io_path(path: str) -> Path:
+    if path == "-":
+        return Path("<stdin>")
+    return Path(path).expanduser()
+
+
+def _display_path(path: str) -> str:
+    return "stdout" if path == "-" else str(_resolve_io_path(path))
+
+
+def _require_mapping(entry: object, *, label: str) -> dict[str, object]:
+    if not isinstance(entry, dict):
+        raise ConfigError(f"{label} must be a mapping")
+    return entry
+
+
+def _require_non_empty_string(value: object, *, field: str, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{label}.{field} must be a non-empty string")
+    return value
+
+
+def _coerce_optional_string(value: object, *, field: str, label: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise ConfigError(f"{label}.{field} must be a string or null")
+    return value
+
+
+def _coerce_bool(value: object, *, field: str, label: str) -> bool:
+    if not isinstance(value, bool):
+        raise ConfigError(f"{label}.{field} must be a boolean")
+    return value
+
+
+def _coerce_string_list(value: object, *, field: str, label: str) -> list[str]:
+    if not isinstance(value, list) or any(not isinstance(item, str) for item in value):
+        raise ConfigError(f"{label}.{field} must be a list of strings")
+    return list(value)
+
+
+def _coerce_object(value: object, *, field: str, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ConfigError(f"{label}.{field} must be a mapping")
+    return value
+
+
+def _coerce_optional_datetime(value: object, *, field: str, label: str) -> datetime | None:
+    if value is None:
+        return None
+    return _require_datetime(value, field=field, label=label)
+
+
+def _require_datetime(value: object, *, field: str, label: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise ConfigError(f"{label}.{field} must be an ISO 8601 timestamp")
+    try:
+        return datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ConfigError(f"{label}.{field} must be an ISO 8601 timestamp") from exc
 
 
 def _print_json(payload: dict[str, object]) -> None:

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -15,8 +15,9 @@ from laminar.config import (
     ensure_default_config,
     validate_source,
 )
-from laminar.models import SourceConfig
+from laminar.models import ContentStatus, SourceConfig
 from laminar.repository import Repository
+from laminar import youtube_api
 from rich.console import Console
 from rich.table import Table
 
@@ -93,6 +94,13 @@ def build_parser() -> argparse.ArgumentParser:
         action="append",
         default=[],
         help="Preferred transcript language for YouTube sources. Repeat to try more than one. Defaults to en.",
+    )
+    add_source.add_argument(
+        "--num-items",
+        dest="num_items",
+        type=int,
+        default=None,
+        help="Maximum number of recent YouTube videos to fetch per scan. Defaults to 5 for YouTube sources.",
     )
     add_source.add_argument(
         "--paid",
@@ -345,6 +353,7 @@ def _run_scan(args: argparse.Namespace) -> int:
                     console.print(f"{source.id}: new {item.title}", style="green")
                 else:
                     console.print(f"{source.id}: existing {item.title}", style="cyan")
+                _report_item_content_status(console, source.id, item)
             repo.finish_scan(
                 scan_id, status="success", items_seen=len(items), items_new=new_count
             )
@@ -497,6 +506,25 @@ def _format_bytes(size_bytes: int) -> str:
     return f"{size_bytes} B"
 
 
+def _report_item_content_status(
+    console: Console,
+    source_id: str,
+    item,
+) -> None:
+    if item.item_type != "video":
+        return
+    if item.content_status == ContentStatus.AVAILABLE:
+        return
+
+    if item.content_status == ContentStatus.MISSING:
+        message = "transcript missing"
+    elif item.content_status == ContentStatus.RATE_LIMITED:
+        message = "transcript rate-limited"
+    else:
+        message = "transcript fetch failed"
+    console.print(f"{source_id}: {message} for {item.title}", style="yellow")
+
+
 def _print_json(payload: dict[str, object]) -> None:
     sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True))
     sys.stdout.write("\n")
@@ -534,6 +562,11 @@ def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
     transcript_languages = args.transcript_language
     if normalized_kind == "youtube" and not transcript_languages:
         transcript_languages = ["en"]
+    if args.num_items is not None and args.num_items < 1:
+        raise ConfigError("--num-items must be at least 1")
+    metadata = _parse_metadata(args.metadata)
+    if normalized_kind == "youtube":
+        metadata = _resolve_youtube_metadata(feed_url, metadata, num_items=args.num_items)
     return SourceConfig(
         id=str(uuid4()),
         kind=normalized_kind,
@@ -543,7 +576,7 @@ def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
         feed_url=feed_url,
         handle=_infer_x_handle(feed_url, normalized_kind),
         transcript_languages=transcript_languages,
-        metadata=_parse_metadata(args.metadata),
+        metadata=metadata,
     )
 
 
@@ -568,9 +601,28 @@ def _resolve_source_kind(url: str, explicit_kind: str | None) -> str:
     host = parsed.netloc.lower()
     if host.endswith("x.com"):
         return "x"
-    if host.endswith("youtube.com") and parsed.path == "/feeds/videos.xml":
+    if youtube_api.looks_like_youtube_url(url):
         return "youtube"
     return "feed"
+
+
+def _resolve_youtube_metadata(
+    url: str,
+    metadata: dict[str, object],
+    *,
+    num_items: int | None,
+) -> dict[str, object]:
+    resolved_metadata = dict(metadata)
+    resolved_metadata["num_items"] = num_items or 5
+    if not youtube_api.looks_like_youtube_url(url):
+        return resolved_metadata
+    try:
+        channel = youtube_api.resolve_channel_from_url(url)
+    except youtube_api.YouTubeApiError as exc:
+        raise ConfigError(f"Could not resolve YouTube source {url}: {exc}") from exc
+    resolved_metadata["channel_id"] = channel.channel_id
+    resolved_metadata["uploads_playlist_id"] = channel.uploads_playlist_id
+    return resolved_metadata
 
 
 def _infer_x_handle(url: str, kind: str) -> str | None:

--- a/src/laminar/cli.py
+++ b/src/laminar/cli.py
@@ -112,7 +112,7 @@ def build_parser() -> argparse.ArgumentParser:
     add_source.add_argument(
         "--paid",
         action="store_true",
-        help="Mark this source as using a paid or metered integration. X sources are paid by default.",
+        help="Mark this source as paid. X sources are paid by default.",
     )
     add_source.add_argument(
         "--disable",
@@ -142,7 +142,7 @@ def build_parser() -> argparse.ArgumentParser:
         "-i",
         "--include-paid",
         action="store_true",
-        help="Include sources marked as paid or metered.",
+        help="Include sources marked as paid.",
     )
     scan_parser.add_argument(
         "-v",
@@ -267,7 +267,7 @@ def _run_source(args: argparse.Namespace) -> int:
             "kind": source.kind,
             "name": source.name,
             "enabled": source.enabled,
-            "costs_money": source.costs_money,
+            "paid": source.paid,
             "feed_url": source.feed_url,
             "handle": source.handle,
             "transcript_languages": source.transcript_languages,
@@ -332,7 +332,7 @@ def _run_source(args: argparse.Namespace) -> int:
             source.id,
             source.kind,
             "enabled" if source.enabled else "disabled",
-            "paid" if source.costs_money else "free",
+            "paid" if source.paid else "free",
             source.name,
         )
     _console().print(table)
@@ -378,7 +378,7 @@ def _run_scan(args: argparse.Namespace) -> int:
         f"scan configuration: {len(active_sources)} active sources, include_paid={args.include_paid}, selected_kinds={sorted(selected_kinds) or ['all']}, selected_ids={sorted(selected) or ['all']}"
     )
     for source in active_sources:
-        if source.costs_money and not args.include_paid:
+        if source.paid and not args.include_paid:
             skipped_at = datetime.now(timezone.utc)
             repo.record_scan_source(
                 run_id,
@@ -400,9 +400,9 @@ def _run_scan(args: argparse.Namespace) -> int:
             continue
         scan_started_at = datetime.now(timezone.utc)
         console.print(f"Scanning {source.id} ({source.name})")
-        if source.costs_money:
+        if source.paid:
             console.print(
-                f"{source.id}: this source uses a paid or metered integration",
+                f"{source.id}: this source is marked paid",
                 style="yellow",
             )
         try:
@@ -756,7 +756,7 @@ def _run_stats(args: argparse.Namespace) -> int:
             source.name,
             source.kind,
             "enabled" if source.enabled else "disabled",
-            "paid" if source.costs_money else "free",
+            "paid" if source.paid else "free",
             str(source.item_count),
             _format_bytes(source.size_bytes),
         )
@@ -831,7 +831,7 @@ def _source_to_export_dict(source: SourceConfig) -> dict[str, object]:
         "kind": source.kind,
         "name": source.name,
         "enabled": source.enabled,
-        "costs_money": source.costs_money,
+        "paid": source.paid,
         "feed_url": source.feed_url,
         "handle": source.handle,
         "transcript_languages": list(source.transcript_languages),
@@ -870,7 +870,7 @@ def _parse_source_import_entry(entry: object, *, index: int) -> SourceConfig:
     kind = _require_non_empty_string(raw.get("kind"), field="kind", label=f"Source entry {index}")
     name = _require_non_empty_string(raw.get("name"), field="name", label=f"Source entry {index}")
     enabled = _coerce_bool(raw.get("enabled", True), field="enabled", label=f"Source entry {index}")
-    costs_money = _coerce_bool(raw.get("costs_money", False), field="costs_money", label=f"Source entry {index}")
+    paid = _coerce_bool(raw.get("paid", False), field="paid", label=f"Source entry {index}")
     feed_url = _coerce_optional_string(raw.get("feed_url"), field="feed_url", label=f"Source entry {index}")
     handle = _coerce_optional_string(raw.get("handle"), field="handle", label=f"Source entry {index}")
     transcript_languages = _coerce_string_list(
@@ -889,7 +889,7 @@ def _parse_source_import_entry(entry: object, *, index: int) -> SourceConfig:
         kind=kind,
         name=name,
         enabled=enabled,
-        costs_money=costs_money,
+        paid=paid,
         feed_url=feed_url,
         handle=handle,
         transcript_languages=transcript_languages,
@@ -1102,7 +1102,7 @@ def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
     feed_url = args.url
     kind = _resolve_source_kind(feed_url, args.kind)
     normalized_kind = kind
-    costs_money = args.paid or normalized_kind == "x"
+    paid = args.paid or normalized_kind == "x"
     transcript_languages = args.transcript_language
     if normalized_kind == "youtube" and not transcript_languages:
         transcript_languages = ["en"]
@@ -1116,7 +1116,7 @@ def _build_source_from_args(args: argparse.Namespace) -> SourceConfig:
         kind=normalized_kind,
         name=args.name,
         enabled=not args.disable,
-        costs_money=costs_money,
+        paid=paid,
         feed_url=feed_url,
         handle=_infer_x_handle(feed_url, normalized_kind),
         transcript_languages=transcript_languages,

--- a/src/laminar/config.py
+++ b/src/laminar/config.py
@@ -39,8 +39,13 @@ def validate_source(source: SourceConfig) -> None:
     if kind not in {"feed", "youtube", "x"}:
         raise ConfigError(f"Source {source.id}: unsupported kind {source.kind!r}")
 
-    if kind in {"feed", "youtube"} and not source.feed_url:
-        raise ConfigError(f"Source {source.id}: {kind} sources require feed_url")
+    if kind == "feed" and not source.feed_url:
+        raise ConfigError(f"Source {source.id}: feed sources require feed_url")
+
+    if kind == "youtube" and not source.feed_url and not source.metadata.get("uploads_playlist_id"):
+        raise ConfigError(
+            f"Source {source.id}: youtube sources require feed_url or metadata.uploads_playlist_id"
+        )
 
     if kind == "x" and not source.feed_url and not source.metadata.get("api_url"):
         raise ConfigError(f"Source {source.id}: x sources require feed_url or api_url")

--- a/src/laminar/models.py
+++ b/src/laminar/models.py
@@ -34,7 +34,7 @@ class SourceConfig:
     kind: str
     name: str
     enabled: bool = True
-    costs_money: bool = False
+    paid: bool = False
     feed_url: str | None = None
     handle: str | None = None
     transcript_languages: list[str] = field(default_factory=list)
@@ -86,7 +86,7 @@ class SourceStats:
     name: str
     kind: str
     enabled: bool
-    costs_money: bool
+    paid: bool
     item_count: int
     size_bytes: int
 

--- a/src/laminar/models.py
+++ b/src/laminar/models.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from enum import StrEnum
 from typing import Any
 from uuid import uuid4
 
@@ -12,6 +13,19 @@ def utc_now() -> datetime:
 
 def new_uuid() -> str:
     return str(uuid4())
+
+
+class ContentStatus(StrEnum):
+    AVAILABLE = "available"
+    MISSING = "missing"
+    FETCH_FAILED = "fetch_failed"
+    RATE_LIMITED = "rate_limited"
+
+    @classmethod
+    def coerce(cls, value: "ContentStatus | str") -> "ContentStatus":
+        if isinstance(value, cls):
+            return value
+        return cls(value)
 
 
 @dataclass(slots=True)
@@ -39,7 +53,7 @@ class NormalizedItem:
     published_at: datetime | None
     excerpt: str | None
     content_text: str | None = None
-    content_status: str = "available"
+    content_status: ContentStatus = ContentStatus.AVAILABLE
     content_language: str | None = None
     content_source: str | None = None
     raw_payload: dict[str, Any] = field(default_factory=dict)
@@ -58,7 +72,7 @@ class StoredItem:
     author: str | None
     excerpt: str | None
     content_text: str | None
-    content_status: str
+    content_status: ContentStatus
     content_language: str | None
     content_source: str | None
     raw_payload: dict[str, Any]

--- a/src/laminar/models.py
+++ b/src/laminar/models.py
@@ -66,9 +66,11 @@ class StoredItem:
     item_id: str
     source_id: str
     item_type: str
+    external_id: str | None
     title: str
     canonical_url: str | None
     published_at: datetime | None
+    retrieved_at: datetime
     author: str | None
     excerpt: str | None
     content_text: str | None
@@ -104,3 +106,63 @@ class RepositoryStats:
     total_size_bytes: int
     sources: list[SourceStats]
     kinds: list[SourceKindStats]
+
+
+@dataclass(slots=True)
+class ScanRunSummary:
+    scan_run_id: int
+    started_at: datetime
+    finished_at: datetime | None
+    status: str
+    include_paid: bool
+    selected_source_kinds: list[str]
+    selected_source_ids: list[str]
+    sources_considered: int
+    sources_scanned: int
+    sources_skipped: int
+    sources_failed: int
+    items_seen: int
+    items_new: int
+    items_existing: int
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class ScanSourceHistory:
+    scan_source_id: int
+    scan_run_id: int
+    source_id: str
+    source_kind: str
+    source_name: str
+    status: str
+    skip_reason: str | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    cutoff_at: datetime | None
+    items_seen: int
+    items_new: int
+    items_existing: int
+    error: str | None = None
+
+
+@dataclass(slots=True)
+class ScanItemHistory:
+    scan_item_id: int
+    scan_source_id: int
+    source_id: str
+    item_id: str | None
+    external_id: str | None
+    canonical_url: str | None
+    title: str
+    published_at: datetime | None
+    result: str
+    content_status: ContentStatus
+    content_source: str | None
+    failure_reason: str | None = None
+
+
+@dataclass(slots=True)
+class ScanRunDetail:
+    run: ScanRunSummary
+    sources: list[ScanSourceHistory]
+    items: list[ScanItemHistory]

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from laminar.models import (
+    ContentStatus,
     NormalizedItem,
     RepositoryStats,
     SourceConfig,
@@ -747,7 +748,7 @@ def _row_to_item(row: sqlite3.Row) -> StoredItem:
         author=row["author"],
         excerpt=row["excerpt"],
         content_text=row["content_text"],
-        content_status=row["content_status"],
+        content_status=ContentStatus.coerce(str(row["content_status"])),
         content_language=row["content_language"],
         content_source=row["content_source"],
         raw_payload=json.loads(row["raw_payload_json"]),

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -27,7 +27,7 @@ CREATE TABLE IF NOT EXISTS sources (
     kind TEXT NOT NULL,
     name TEXT NOT NULL,
     enabled INTEGER NOT NULL,
-    costs_money INTEGER NOT NULL DEFAULT 0,
+    paid INTEGER NOT NULL DEFAULT 0,
     feed_url TEXT,
     handle TEXT,
     transcript_languages_json TEXT NOT NULL DEFAULT '[]',
@@ -174,7 +174,7 @@ class Repository:
             conn.execute(
                 """
                 INSERT INTO sources (
-                    source_id, kind, name, enabled, costs_money, feed_url, handle,
+                    source_id, kind, name, enabled, paid, feed_url, handle,
                     transcript_languages_json, metadata_json,
                     last_successful_scan_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -182,7 +182,7 @@ class Repository:
                     kind = excluded.kind,
                     name = excluded.name,
                     enabled = excluded.enabled,
-                    costs_money = excluded.costs_money,
+                    paid = excluded.paid,
                     feed_url = excluded.feed_url,
                     handle = excluded.handle,
                     transcript_languages_json = excluded.transcript_languages_json,
@@ -194,7 +194,7 @@ class Repository:
                     source.kind,
                     source.name,
                     int(source.enabled),
-                    int(source.costs_money),
+                    int(source.paid),
                     source.feed_url,
                     source.handle,
                     json.dumps(source.transcript_languages),
@@ -212,7 +212,7 @@ class Repository:
                     kind,
                     name,
                     enabled,
-                    costs_money,
+                    paid,
                     feed_url,
                     handle,
                     transcript_languages_json,
@@ -233,7 +233,7 @@ class Repository:
                     kind,
                     name,
                     enabled,
-                    costs_money,
+                    paid,
                     feed_url,
                     handle,
                     transcript_languages_json,
@@ -895,7 +895,7 @@ class Repository:
                     s.name,
                     s.kind,
                     s.enabled,
-                    s.costs_money,
+                    s.paid,
                     COALESCE(sis.item_count, 0) AS item_count,
                     COALESCE(sis.size_bytes, 0) AS size_bytes
                 FROM sources s
@@ -906,7 +906,7 @@ class Repository:
                     '[missing source]' AS name,
                     'missing' AS kind,
                     0 AS enabled,
-                    0 AS costs_money,
+                    0 AS paid,
                     sis.item_count,
                     sis.size_bytes
                 FROM source_item_stats sis
@@ -993,7 +993,7 @@ class Repository:
                     name=str(row["name"]),
                     kind=str(row["kind"]),
                     enabled=bool(row["enabled"]),
-                    costs_money=bool(row["costs_money"]),
+                    paid=bool(row["paid"]),
                     item_count=int(row["item_count"]),
                     size_bytes=int(row["size_bytes"]),
                 )
@@ -1086,7 +1086,7 @@ def _row_to_source(row: sqlite3.Row) -> SourceConfig:
         kind=kind,
         name=row["name"],
         enabled=bool(row["enabled"]),
-        costs_money=bool(row["costs_money"]),
+        paid=bool(row["paid"]),
         feed_url=row["feed_url"],
         handle=row["handle"],
         transcript_languages=_json_list(row["transcript_languages_json"]),

--- a/src/laminar/repository.py
+++ b/src/laminar/repository.py
@@ -10,6 +10,10 @@ from laminar.models import (
     ContentStatus,
     NormalizedItem,
     RepositoryStats,
+    ScanItemHistory,
+    ScanRunDetail,
+    ScanRunSummary,
+    ScanSourceHistory,
     SourceConfig,
     SourceKindStats,
     SourceStats,
@@ -42,6 +46,70 @@ CREATE TABLE IF NOT EXISTS scans (
     items_new INTEGER NOT NULL DEFAULT 0,
     error TEXT
 );
+
+CREATE TABLE IF NOT EXISTS scan_runs (
+    scan_run_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    started_at TEXT NOT NULL,
+    finished_at TEXT,
+    status TEXT NOT NULL,
+    include_paid INTEGER NOT NULL DEFAULT 0,
+    selected_source_kinds_json TEXT NOT NULL DEFAULT '[]',
+    selected_source_ids_json TEXT NOT NULL DEFAULT '[]',
+    sources_considered INTEGER NOT NULL DEFAULT 0,
+    sources_scanned INTEGER NOT NULL DEFAULT 0,
+    sources_skipped INTEGER NOT NULL DEFAULT 0,
+    sources_failed INTEGER NOT NULL DEFAULT 0,
+    items_seen INTEGER NOT NULL DEFAULT 0,
+    items_new INTEGER NOT NULL DEFAULT 0,
+    items_existing INTEGER NOT NULL DEFAULT 0,
+    error TEXT
+);
+
+CREATE TABLE IF NOT EXISTS scan_sources (
+    scan_source_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_run_id INTEGER NOT NULL,
+    source_id TEXT NOT NULL,
+    source_kind TEXT NOT NULL,
+    source_name TEXT NOT NULL,
+    status TEXT NOT NULL,
+    skip_reason TEXT,
+    started_at TEXT,
+    finished_at TEXT,
+    cutoff_at TEXT,
+    items_seen INTEGER NOT NULL DEFAULT 0,
+    items_new INTEGER NOT NULL DEFAULT 0,
+    items_existing INTEGER NOT NULL DEFAULT 0,
+    error TEXT,
+    FOREIGN KEY(scan_run_id) REFERENCES scan_runs(scan_run_id)
+);
+
+CREATE TABLE IF NOT EXISTS scan_items (
+    scan_item_id INTEGER PRIMARY KEY AUTOINCREMENT,
+    scan_source_id INTEGER NOT NULL,
+    source_id TEXT NOT NULL,
+    item_id TEXT,
+    external_id TEXT,
+    canonical_url TEXT,
+    title TEXT NOT NULL,
+    published_at TEXT,
+    result TEXT NOT NULL,
+    content_status TEXT NOT NULL,
+    content_source TEXT,
+    failure_reason TEXT,
+    FOREIGN KEY(scan_source_id) REFERENCES scan_sources(scan_source_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scan_sources_run_id
+ON scan_sources(scan_run_id);
+
+CREATE INDEX IF NOT EXISTS idx_scan_sources_source_id
+ON scan_sources(source_id);
+
+CREATE INDEX IF NOT EXISTS idx_scan_items_scan_source_id
+ON scan_items(scan_source_id);
+
+CREATE INDEX IF NOT EXISTS idx_scan_items_source_id
+ON scan_items(source_id);
 
 CREATE TABLE IF NOT EXISTS items (
     item_id TEXT PRIMARY KEY,
@@ -210,6 +278,36 @@ class Repository:
                 for title in {str(row["title"]) for row in item_rows}:
                     self._refresh_title_map_for_title(conn, title)
 
+            scan_source_ids = [
+                int(row["scan_source_id"])
+                for row in conn.execute(
+                    "SELECT scan_source_id FROM scan_sources WHERE source_id = ?",
+                    (source_id,),
+                ).fetchall()
+            ]
+            if scan_source_ids:
+                placeholders = ",".join("?" for _ in scan_source_ids)
+                conn.execute(
+                    f"DELETE FROM scan_items WHERE scan_source_id IN ({placeholders})",
+                    scan_source_ids,
+                )
+                conn.execute(
+                    f"DELETE FROM scan_sources WHERE scan_source_id IN ({placeholders})",
+                    scan_source_ids,
+                )
+                conn.execute(
+                    """
+                    DELETE FROM scan_runs
+                    WHERE scan_run_id IN (
+                        SELECT sr.scan_run_id
+                        FROM scan_runs sr
+                        LEFT JOIN scan_sources ss ON ss.scan_run_id = sr.scan_run_id
+                        GROUP BY sr.scan_run_id
+                        HAVING COUNT(ss.scan_source_id) = 0
+                    )
+                    """
+                )
+
             conn.execute("DELETE FROM scans WHERE source_id = ?", (source_id,))
             conn.execute("DELETE FROM sources WHERE source_id = ?", (source_id,))
             return len(item_rows)
@@ -240,32 +338,254 @@ class Repository:
                 (_dt(timestamp), source_id),
             )
 
-    def start_scan(self, source_id: str | None) -> int:
+    def start_scan_run(
+        self,
+        *,
+        include_paid: bool,
+        selected_source_kinds: list[str],
+        selected_source_ids: list[str],
+        started_at: datetime | None = None,
+    ) -> int:
+        timestamp = started_at or datetime.now(timezone.utc)
         with self.connect() as conn:
             cursor = conn.execute(
-                "INSERT INTO scans (started_at, source_id, status) VALUES (CURRENT_TIMESTAMP, ?, ?)",
-                (source_id, "running"),
+                """
+                INSERT INTO scan_runs (
+                    started_at,
+                    status,
+                    include_paid,
+                    selected_source_kinds_json,
+                    selected_source_ids_json
+                ) VALUES (?, ?, ?, ?, ?)
+                """,
+                (
+                    _dt(timestamp),
+                    "running",
+                    int(include_paid),
+                    json.dumps(selected_source_kinds),
+                    json.dumps(selected_source_ids),
+                ),
             )
             return int(cursor.lastrowid)
 
-    def finish_scan(
+    def record_scan_source(
         self,
-        scan_id: int,
+        scan_run_id: int,
         *,
+        source: SourceConfig,
         status: str,
+        skip_reason: str | None = None,
+        started_at: datetime | None = None,
+        finished_at: datetime | None = None,
+        cutoff_at: datetime | None = None,
         items_seen: int,
         items_new: int,
+        items_existing: int,
+        error: str | None = None,
+    ) -> int:
+        with self.connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO scan_sources (
+                    scan_run_id,
+                    source_id,
+                    source_kind,
+                    source_name,
+                    status,
+                    skip_reason,
+                    started_at,
+                    finished_at,
+                    cutoff_at,
+                    items_seen,
+                    items_new,
+                    items_existing,
+                    error
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    scan_run_id,
+                    source.id,
+                    source.kind,
+                    source.name,
+                    status,
+                    skip_reason,
+                    _dt(started_at),
+                    _dt(finished_at),
+                    _dt(cutoff_at),
+                    items_seen,
+                    items_new,
+                    items_existing,
+                    error,
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def update_scan_source(
+        self,
+        scan_source_id: int,
+        *,
+        status: str,
+        skip_reason: str | None = None,
+        started_at: datetime | None = None,
+        finished_at: datetime | None = None,
+        cutoff_at: datetime | None = None,
+        items_seen: int,
+        items_new: int,
+        items_existing: int,
         error: str | None = None,
     ) -> None:
         with self.connect() as conn:
             conn.execute(
                 """
-                UPDATE scans
-                SET finished_at = CURRENT_TIMESTAMP, status = ?, items_seen = ?, items_new = ?, error = ?
-                WHERE scan_id = ?
+                UPDATE scan_sources
+                SET status = ?, skip_reason = ?, started_at = ?, finished_at = ?, cutoff_at = ?,
+                    items_seen = ?, items_new = ?, items_existing = ?, error = ?
+                WHERE scan_source_id = ?
                 """,
-                (status, items_seen, items_new, error, scan_id),
+                (
+                    status,
+                    skip_reason,
+                    _dt(started_at),
+                    _dt(finished_at),
+                    _dt(cutoff_at),
+                    items_seen,
+                    items_new,
+                    items_existing,
+                    error,
+                    scan_source_id,
+                ),
             )
+
+    def record_scan_item(
+        self,
+        scan_source_id: int,
+        item: NormalizedItem,
+        *,
+        result: str,
+        failure_reason: str | None = None,
+    ) -> int:
+        with self.connect() as conn:
+            cursor = conn.execute(
+                """
+                INSERT INTO scan_items (
+                    scan_source_id,
+                    source_id,
+                    item_id,
+                    external_id,
+                    canonical_url,
+                    title,
+                    published_at,
+                    result,
+                    content_status,
+                    content_source,
+                    failure_reason
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    scan_source_id,
+                    item.source_id,
+                    item.item_id,
+                    item.external_id,
+                    item.canonical_url,
+                    item.title,
+                    _dt(item.published_at),
+                    result,
+                    item.content_status,
+                    item.content_source,
+                    failure_reason,
+                ),
+            )
+            return int(cursor.lastrowid)
+
+    def finish_scan_run(
+        self,
+        scan_run_id: int,
+        *,
+        status: str,
+        sources_considered: int,
+        sources_scanned: int,
+        sources_skipped: int,
+        sources_failed: int,
+        items_seen: int,
+        items_new: int,
+        items_existing: int,
+        error: str | None = None,
+        finished_at: datetime | None = None,
+    ) -> None:
+        timestamp = finished_at or datetime.now(timezone.utc)
+        with self.connect() as conn:
+            conn.execute(
+                """
+                UPDATE scan_runs
+                SET finished_at = ?, status = ?, sources_considered = ?, sources_scanned = ?,
+                    sources_skipped = ?, sources_failed = ?, items_seen = ?, items_new = ?,
+                    items_existing = ?, error = ?
+                WHERE scan_run_id = ?
+                """,
+                (
+                    _dt(timestamp),
+                    status,
+                    sources_considered,
+                    sources_scanned,
+                    sources_skipped,
+                    sources_failed,
+                    items_seen,
+                    items_new,
+                    items_existing,
+                    error,
+                    scan_run_id,
+                ),
+            )
+
+    def list_scan_runs(self, *, limit: int = 20) -> list[ScanRunSummary]:
+        with self.connect() as conn:
+            rows = conn.execute(
+                """
+                SELECT *
+                FROM scan_runs
+                ORDER BY scan_run_id DESC
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        return [_row_to_scan_run(row) for row in rows]
+
+    def get_scan_run(self, scan_run_id: int) -> ScanRunDetail | None:
+        with self.connect() as conn:
+            run_row = conn.execute(
+                """
+                SELECT *
+                FROM scan_runs
+                WHERE scan_run_id = ?
+                """,
+                (scan_run_id,),
+            ).fetchone()
+            if run_row is None:
+                return None
+            source_rows = conn.execute(
+                """
+                SELECT *
+                FROM scan_sources
+                WHERE scan_run_id = ?
+                ORDER BY scan_source_id
+                """,
+                (scan_run_id,),
+            ).fetchall()
+            item_rows = conn.execute(
+                """
+                SELECT si.*
+                FROM scan_items si
+                JOIN scan_sources ss ON ss.scan_source_id = si.scan_source_id
+                WHERE ss.scan_run_id = ?
+                ORDER BY si.scan_item_id
+                """,
+                (scan_run_id,),
+            ).fetchall()
+        return ScanRunDetail(
+            run=_row_to_scan_run(run_row),
+            sources=[_row_to_scan_source(row) for row in source_rows],
+            items=[_row_to_scan_item(row) for row in item_rows],
+        )
 
     def upsert_item(self, item: NormalizedItem) -> bool:
         payload_json = json.dumps(item.raw_payload, sort_keys=True)
@@ -366,7 +686,7 @@ class Repository:
         *,
         source_id: str | None = None,
         item_type: str | None = None,
-        limit: int = 20,
+        limit: int | None = 20,
     ) -> list[StoredItem]:
         conditions = []
         params: list[object] = []
@@ -378,15 +698,17 @@ class Repository:
             params.append(item_type)
 
         where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+        limit_clause = "LIMIT ?" if limit is not None else ""
         query = f"""
             SELECT i.*, c.content_text
             FROM items i
             LEFT JOIN item_contents c ON c.item_id = i.item_id
             {where_clause}
             ORDER BY COALESCE(i.published_at, i.retrieved_at) DESC
-            LIMIT ?
+            {limit_clause}
         """
-        params.append(limit)
+        if limit is not None:
+            params.append(limit)
         with self.connect() as conn:
             rows = conn.execute(query, params).fetchall()
         return [_row_to_item(row) for row in rows]
@@ -742,9 +1064,11 @@ def _row_to_item(row: sqlite3.Row) -> StoredItem:
         item_id=str(row["item_id"]),
         source_id=row["source_id"],
         item_type=row["item_type"],
+        external_id=row["external_id"],
         title=row["title"],
         canonical_url=row["canonical_url"],
         published_at=_parse_dt(row["published_at"]),
+        retrieved_at=_parse_dt(row["retrieved_at"]) or datetime.now(timezone.utc),
         author=row["author"],
         excerpt=row["excerpt"],
         content_text=row["content_text"],
@@ -768,6 +1092,62 @@ def _row_to_source(row: sqlite3.Row) -> SourceConfig:
         transcript_languages=_json_list(row["transcript_languages_json"]),
         metadata=_json_object(row["metadata_json"]),
         last_successful_scan_at=_parse_dt(row["last_successful_scan_at"]),
+    )
+
+
+def _row_to_scan_run(row: sqlite3.Row) -> ScanRunSummary:
+    return ScanRunSummary(
+        scan_run_id=int(row["scan_run_id"]),
+        started_at=_parse_dt(row["started_at"]) or datetime.now(timezone.utc),
+        finished_at=_parse_dt(row["finished_at"]),
+        status=str(row["status"]),
+        include_paid=bool(row["include_paid"]),
+        selected_source_kinds=_json_list(row["selected_source_kinds_json"]),
+        selected_source_ids=_json_list(row["selected_source_ids_json"]),
+        sources_considered=int(row["sources_considered"]),
+        sources_scanned=int(row["sources_scanned"]),
+        sources_skipped=int(row["sources_skipped"]),
+        sources_failed=int(row["sources_failed"]),
+        items_seen=int(row["items_seen"]),
+        items_new=int(row["items_new"]),
+        items_existing=int(row["items_existing"]),
+        error=row["error"],
+    )
+
+
+def _row_to_scan_source(row: sqlite3.Row) -> ScanSourceHistory:
+    return ScanSourceHistory(
+        scan_source_id=int(row["scan_source_id"]),
+        scan_run_id=int(row["scan_run_id"]),
+        source_id=str(row["source_id"]),
+        source_kind=str(row["source_kind"]),
+        source_name=str(row["source_name"]),
+        status=str(row["status"]),
+        skip_reason=row["skip_reason"],
+        started_at=_parse_dt(row["started_at"]),
+        finished_at=_parse_dt(row["finished_at"]),
+        cutoff_at=_parse_dt(row["cutoff_at"]),
+        items_seen=int(row["items_seen"]),
+        items_new=int(row["items_new"]),
+        items_existing=int(row["items_existing"]),
+        error=row["error"],
+    )
+
+
+def _row_to_scan_item(row: sqlite3.Row) -> ScanItemHistory:
+    return ScanItemHistory(
+        scan_item_id=int(row["scan_item_id"]),
+        scan_source_id=int(row["scan_source_id"]),
+        source_id=str(row["source_id"]),
+        item_id=row["item_id"],
+        external_id=row["external_id"],
+        canonical_url=row["canonical_url"],
+        title=str(row["title"]),
+        published_at=_parse_dt(row["published_at"]),
+        result=str(row["result"]),
+        content_status=ContentStatus.coerce(str(row["content_status"])),
+        content_source=row["content_source"],
+        failure_reason=row["failure_reason"],
     )
 
 

--- a/src/laminar/youtube.py
+++ b/src/laminar/youtube.py
@@ -4,10 +4,15 @@ from dataclasses import dataclass
 from urllib.parse import parse_qs, urlparse
 
 from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api import _errors as transcript_errors
+
+from laminar.models import ContentStatus
 
 
 class TranscriptUnavailable(Exception):
-    pass
+    def __init__(self, message: str, *, content_status: ContentStatus) -> None:
+        super().__init__(message)
+        self.content_status = content_status
 
 
 @dataclass(slots=True)
@@ -52,7 +57,10 @@ def fetch_transcript(
         transcript = api.list(video_id).find_transcript(language_preferences)
         fetched = transcript.fetch()
     except Exception as exc:  # pragma: no cover - third-party exceptions vary
-        raise TranscriptUnavailable(str(exc)) from exc
+        raise TranscriptUnavailable(
+            str(exc),
+            content_status=_status_from_transcript_error(exc),
+        ) from exc
 
     segments = [
         TranscriptSegment(
@@ -65,7 +73,10 @@ def fetch_transcript(
         if snippet.text.strip()
     ]
     if not segments:
-        raise TranscriptUnavailable("Transcript was empty")
+        raise TranscriptUnavailable(
+            "Transcript was empty",
+            content_status=ContentStatus.MISSING,
+        )
 
     return TranscriptResult(
         text="\n".join(segment.text for segment in segments),
@@ -77,6 +88,33 @@ def fetch_transcript(
         is_generated=transcript.is_generated,
         segments=segments,
     )
+
+
+def _status_from_transcript_error(exc: Exception) -> ContentStatus:
+    if isinstance(
+        exc,
+        (
+            transcript_errors.IpBlocked,
+            transcript_errors.RequestBlocked,
+            transcript_errors.YouTubeRequestFailed,
+            transcript_errors.PoTokenRequired,
+        ),
+    ):
+        return ContentStatus.RATE_LIMITED
+
+    if isinstance(
+        exc,
+        (
+            transcript_errors.NoTranscriptFound,
+            transcript_errors.TranscriptsDisabled,
+            transcript_errors.NotTranslatable,
+            transcript_errors.TranslationLanguageNotAvailable,
+        ),
+    ):
+        return ContentStatus.MISSING
+
+    return ContentStatus.FETCH_FAILED
+
 
 
 def format_timestamp(seconds: float) -> str:

--- a/src/laminar/youtube_api.py
+++ b/src/laminar/youtube_api.py
@@ -1,0 +1,358 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterator
+from urllib.parse import parse_qs, urlparse
+
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+from laminar.youtube import extract_video_id
+
+
+class YouTubeApiError(RuntimeError):
+    pass
+
+
+@dataclass(slots=True)
+class YouTubeChannel:
+    channel_id: str
+    title: str | None
+    uploads_playlist_id: str
+
+
+@dataclass(slots=True)
+class YouTubeUpload:
+    video_id: str
+    title: str
+    description: str | None
+    channel_title: str | None
+    published_at: datetime | None
+    canonical_url: str
+
+
+def looks_like_youtube_url(url: str | None) -> bool:
+    if not url:
+        return False
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    return host == "youtu.be" or host.endswith("youtube.com")
+
+
+def resolve_channel_from_url(
+    url: str,
+    *,
+    api_key: str | None = None,
+) -> YouTubeChannel:
+    channel_id = _channel_id_from_feed_url(url) or _channel_id_from_channel_url(url)
+    if channel_id:
+        return get_channel(channel_id, api_key=api_key)
+
+    video_id = extract_video_id(url)
+    if video_id:
+        return _channel_from_video_id(video_id, api_key=api_key)
+
+    handle = _handle_from_url(url)
+    if handle:
+        return get_channel_by_handle(handle, api_key=api_key)
+
+    username = _username_from_url(url)
+    if username:
+        return get_channel_by_username(username, api_key=api_key)
+
+    raise YouTubeApiError(
+        "Unsupported YouTube URL; use a watch URL, youtu.be URL, /channel/ URL, @handle URL, /user/ URL, or feeds/videos.xml?channel_id=..."
+    )
+
+
+def get_channel(
+    channel_id: str,
+    *,
+    api_key: str | None = None,
+) -> YouTubeChannel:
+    service = _service(api_key)
+    try:
+        response = (
+            service.channels()
+            .list(part="snippet,contentDetails", id=channel_id)
+            .execute()
+        )
+    except HttpError as exc:  # pragma: no cover - network/runtime dependent
+        raise YouTubeApiError(str(exc)) from exc
+    return _channel_from_response(response, label=f"channel id {channel_id}")
+
+
+def get_channel_by_handle(
+    handle: str,
+    *,
+    api_key: str | None = None,
+) -> YouTubeChannel:
+    service = _service(api_key)
+    normalized_handle = handle.lstrip("@")
+    try:
+        response = (
+            service.channels()
+            .list(part="snippet,contentDetails", forHandle=normalized_handle)
+            .execute()
+        )
+    except HttpError as exc:  # pragma: no cover - network/runtime dependent
+        raise YouTubeApiError(str(exc)) from exc
+    return _channel_from_response(response, label=f"handle @{normalized_handle}")
+
+
+def get_channel_by_username(
+    username: str,
+    *,
+    api_key: str | None = None,
+) -> YouTubeChannel:
+    service = _service(api_key)
+    try:
+        response = (
+            service.channels()
+            .list(part="snippet,contentDetails", forUsername=username)
+            .execute()
+        )
+    except HttpError as exc:  # pragma: no cover - network/runtime dependent
+        raise YouTubeApiError(str(exc)) from exc
+    return _channel_from_response(response, label=f"username {username}")
+
+
+def iter_uploads(
+    uploads_playlist_id: str,
+    *,
+    api_key: str | None = None,
+    page_size: int = 50,
+    limit: int | None = None,
+) -> Iterator[YouTubeUpload]:
+    service = _service(api_key)
+    next_page_token: str | None = None
+    remaining = limit
+
+    while True:
+        batch_size = page_size
+        if remaining is not None:
+            if remaining <= 0:
+                break
+            batch_size = min(batch_size, remaining)
+        request = service.playlistItems().list(
+            part="snippet,contentDetails",
+            playlistId=uploads_playlist_id,
+            maxResults=batch_size,
+            pageToken=next_page_token,
+        )
+        try:
+            response = request.execute()
+        except HttpError as exc:  # pragma: no cover - network/runtime dependent
+            raise YouTubeApiError(str(exc)) from exc
+
+        items = response.get("items", [])
+        if not isinstance(items, list):
+            raise YouTubeApiError("playlistItems.list returned a malformed response")
+
+        for raw_item in items:
+            upload = _upload_from_response_item(raw_item)
+            if upload is None:
+                continue
+            yield upload
+            if remaining is not None:
+                remaining -= 1
+                if remaining <= 0:
+                    return
+
+        next_page_token = response.get("nextPageToken")
+        if not isinstance(next_page_token, str) or not next_page_token:
+            break
+
+
+def _api_key(explicit_api_key: str | None = None) -> str:
+    api_key = explicit_api_key or os.environ.get("YOUTUBE_API_KEY")
+    if not api_key:
+        raise YouTubeApiError("Missing YOUTUBE_API_KEY")
+    return api_key
+
+
+def _service(api_key: str | None = None):
+    return build(
+        "youtube",
+        "v3",
+        developerKey=_api_key(api_key),
+        cache_discovery=False,
+    )
+
+
+def _channel_from_video_id(
+    video_id: str,
+    *,
+    api_key: str | None = None,
+) -> YouTubeChannel:
+    service = _service(api_key)
+    try:
+        response = service.videos().list(part="snippet", id=video_id).execute()
+    except HttpError as exc:  # pragma: no cover - network/runtime dependent
+        raise YouTubeApiError(str(exc)) from exc
+
+    items = response.get("items", [])
+    if not isinstance(items, list) or not items:
+        raise YouTubeApiError(f"No video found for id {video_id}")
+
+    first = items[0]
+    if not isinstance(first, dict):
+        raise YouTubeApiError("videos.list returned a malformed response")
+
+    snippet = first.get("snippet")
+    if not isinstance(snippet, dict):
+        raise YouTubeApiError("videos.list response was missing snippet")
+
+    channel_id = snippet.get("channelId")
+    if not isinstance(channel_id, str) or not channel_id:
+        raise YouTubeApiError("videos.list response was missing snippet.channelId")
+
+    return get_channel(channel_id, api_key=api_key)
+
+
+def _channel_from_response(response: object, *, label: str) -> YouTubeChannel:
+    if not isinstance(response, dict):
+        raise YouTubeApiError("YouTube API returned a malformed response")
+
+    items = response.get("items", [])
+    if not isinstance(items, list) or not items:
+        raise YouTubeApiError(f"No channel found for {label}")
+
+    first = items[0]
+    if not isinstance(first, dict):
+        raise YouTubeApiError("YouTube API returned a malformed channel entry")
+
+    channel_id = first.get("id")
+    snippet = first.get("snippet")
+    content_details = first.get("contentDetails")
+    if not isinstance(channel_id, str) or not channel_id:
+        raise YouTubeApiError("channels.list response was missing id")
+    if not isinstance(snippet, dict):
+        raise YouTubeApiError("channels.list response was missing snippet")
+    if not isinstance(content_details, dict):
+        raise YouTubeApiError("channels.list response was missing contentDetails")
+
+    related_playlists = content_details.get("relatedPlaylists")
+    if not isinstance(related_playlists, dict):
+        raise YouTubeApiError(
+            "channels.list response was missing contentDetails.relatedPlaylists"
+        )
+
+    uploads_playlist_id = related_playlists.get("uploads")
+    if not isinstance(uploads_playlist_id, str) or not uploads_playlist_id:
+        raise YouTubeApiError("Channel did not expose an uploads playlist")
+
+    title = snippet.get("title")
+    if not isinstance(title, str) or not title.strip():
+        title = None
+
+    return YouTubeChannel(
+        channel_id=channel_id,
+        title=title,
+        uploads_playlist_id=uploads_playlist_id,
+    )
+
+
+def _upload_from_response_item(raw_item: object) -> YouTubeUpload | None:
+    if not isinstance(raw_item, dict):
+        return None
+
+    snippet = raw_item.get("snippet")
+    content_details = raw_item.get("contentDetails")
+    if not isinstance(snippet, dict) or not isinstance(content_details, dict):
+        return None
+
+    video_id = content_details.get("videoId")
+    if not isinstance(video_id, str) or not video_id:
+        resource_id = snippet.get("resourceId")
+        if isinstance(resource_id, dict):
+            maybe_video_id = resource_id.get("videoId")
+            if isinstance(maybe_video_id, str) and maybe_video_id:
+                video_id = maybe_video_id
+    if not video_id:
+        return None
+
+    title = snippet.get("title")
+    if not isinstance(title, str) or not title.strip():
+        title = "(untitled video)"
+
+    description = snippet.get("description")
+    if not isinstance(description, str):
+        description = None
+
+    channel_title = snippet.get("videoOwnerChannelTitle")
+    if not isinstance(channel_title, str) or not channel_title.strip():
+        channel_title = snippet.get("channelTitle")
+    if not isinstance(channel_title, str) or not channel_title.strip():
+        channel_title = None
+
+    return YouTubeUpload(
+        video_id=video_id,
+        title=title,
+        description=description,
+        channel_title=channel_title,
+        published_at=_parse_dt(snippet.get("publishedAt")),
+        canonical_url=f"https://www.youtube.com/watch?v={video_id}",
+    )
+
+
+def _channel_id_from_feed_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not looks_like_youtube_url(url) or parsed.path != "/feeds/videos.xml":
+        return None
+    values = parse_qs(parsed.query)
+    channel_ids = values.get("channel_id", [])
+    if not channel_ids:
+        return None
+    channel_id = channel_ids[0].strip()
+    return channel_id or None
+
+
+def _channel_id_from_channel_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not looks_like_youtube_url(url):
+        return None
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) >= 2 and path_parts[0] == "channel":
+        channel_id = path_parts[1].strip()
+        return channel_id or None
+    return None
+
+
+def _handle_from_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not looks_like_youtube_url(url):
+        return None
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if path_parts and path_parts[0].startswith("@"):
+        handle = path_parts[0].lstrip("@").strip()
+        return handle or None
+    return None
+
+
+def _username_from_url(url: str) -> str | None:
+    parsed = urlparse(url)
+    if not looks_like_youtube_url(url):
+        return None
+    path_parts = [part for part in parsed.path.split("/") if part]
+    if len(path_parts) >= 2 and path_parts[0] == "user":
+        username = path_parts[1].strip()
+        return username or None
+    return None
+
+
+def _parse_dt(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+    ):
+        try:
+            return datetime.strptime(value, fmt).astimezone(timezone.utc)
+        except ValueError:
+            continue
+    return None

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from urllib.error import HTTPError
 from uuid import UUID
 
 import pytest
+import yaml
 
 import laminar.adapters as adapters
 import laminar.cli as cli
@@ -380,6 +381,20 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
     assert "scan complete: 2 items seen, 1 new, 1 failed, 0 skipped" in output
     items = repo.list_items(limit=10)
     assert any(item.title == "Brand new" for item in items)
+    runs = repo.list_scan_runs(limit=10)
+    assert len(runs) == 1
+    assert runs[0].status == "partial_failure"
+    assert runs[0].sources_considered == 2
+    assert runs[0].sources_scanned == 2
+    assert runs[0].sources_failed == 1
+    assert runs[0].items_seen == 2
+    assert runs[0].items_new == 1
+    assert runs[0].items_existing == 1
+    detail = repo.get_scan_run(runs[0].scan_run_id)
+    assert detail is not None
+    assert [source.status for source in detail.sources] == ["failed", "success"]
+    assert detail.sources[0].error == "HTTP Error 404: Not Found"
+    assert [item.result for item in detail.items] == ["existing", "new"]
 
 
 def test_scan_skips_paid_sources_without_include_paid(tmp_path: Path) -> None:
@@ -426,6 +441,93 @@ def test_scan_skips_paid_sources_without_include_paid(tmp_path: Path) -> None:
     assert "Skipping paid-source (Paid X): paid source; rerun with --include-paid" in output
     assert "Scanning paid-source" not in output
     assert "scan complete: 0 items seen, 0 new, 0 failed, 1 skipped" in output
+    runs = repo.list_scan_runs(limit=10)
+    assert len(runs) == 1
+    assert runs[0].status == "success"
+    assert runs[0].sources_considered == 1
+    assert runs[0].sources_scanned == 0
+    assert runs[0].sources_skipped == 1
+    detail = repo.get_scan_run(runs[0].scan_run_id)
+    assert detail is not None
+    assert len(detail.sources) == 1
+    assert detail.sources[0].status == "skipped"
+    assert detail.sources[0].skip_reason == "paid_not_included"
+
+def test_scans_list_and_show_report_history(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    source = SourceConfig(id="feed-1", kind="feed", name="Example Feed")
+    repo.upsert_source(source)
+    run_id = repo.start_scan_run(
+        include_paid=False,
+        selected_source_kinds=["feed"],
+        selected_source_ids=["feed-1"],
+        started_at=datetime(2026, 4, 18, 12, 0, tzinfo=timezone.utc),
+    )
+    scan_source_id = repo.record_scan_source(
+        run_id,
+        source=source,
+        status="success",
+        started_at=datetime(2026, 4, 18, 12, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2026, 4, 18, 12, 1, tzinfo=timezone.utc),
+        cutoff_at=datetime(2026, 4, 17, 12, 0, tzinfo=timezone.utc),
+        items_seen=1,
+        items_new=1,
+        items_existing=0,
+    )
+    repo.record_scan_item(
+        scan_source_id,
+        NormalizedItem(
+            item_id="11111111-1111-4111-8111-111111111111",
+            source_id="feed-1",
+            item_type="feed",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Fresh Post",
+            author="Author",
+            published_at=datetime(2026, 4, 18, 11, 30, tzinfo=timezone.utc),
+            excerpt="Fresh",
+            content_text="Fresh",
+        ),
+        result="new",
+    )
+    repo.finish_scan_run(
+        run_id,
+        status="success",
+        sources_considered=1,
+        sources_scanned=1,
+        sources_skipped=0,
+        sources_failed=0,
+        items_seen=1,
+        items_new=1,
+        items_existing=0,
+        finished_at=datetime(2026, 4, 18, 12, 2, tzinfo=timezone.utc),
+    )
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        args = parser.parse_args(["--db", str(db_path), "scans", "list"])
+        assert run(args) == 0
+    output = buffer.getvalue()
+    assert "Scans" in output
+    assert "Run" in output
+    assert "success" in output
+    assert "feed" in output
+    assert "1/1" in output
+    assert "1 seen" in output
+    assert "1 new" in output
+    assert "0 existing" in output
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        args = parser.parse_args(["--db", str(db_path), "scans", "show", str(run_id)])
+        assert run(args) == 0
+    payload = json.loads(buffer.getvalue())
+    assert payload["run"]["scan_run_id"] == run_id
+    assert payload["run"]["status"] == "success"
+    assert payload["sources"][0]["source_id"] == "feed-1"
+    assert payload["sources"][0]["cutoff_at"] == "2026-04-17T12:00:00+00:00"
+    assert payload["items"][0]["title"] == "Fresh Post"
+    assert payload["items"][0]["result"] == "new"
 
 
 def test_scan_uses_last_successful_scan_time_for_incremental_blog_and_youtube(
@@ -649,6 +751,8 @@ def test_scan_uses_youtube_api_uploads_playlist_metadata(tmp_path: Path) -> None
 
     output = scan_buffer.getvalue()
     assert "Scanning youtube-source (Example Channel)" in output
+    assert "youtube-source: discovered New API Video (new123)" in output
+    assert "youtube-source: transcript found for new123" in output
     assert "youtube-source: new New API Video" in output
     assert "youtube-source: new Old API Video" not in output
     assert fetch_calls == ["new123"]
@@ -746,6 +850,8 @@ def test_scan_stops_after_youtube_transcript_failure(tmp_path: Path) -> None:
         adapters.fetch_transcript = original_fetch
 
     output = scan_buffer.getvalue()
+    assert "youtube-source: discovered New API Video (new123)" in output
+    assert "youtube-source: transcript rate-limited for new123" in output
     assert "youtube-source: new New API Video" in output
     assert "youtube-source: transcript rate-limited for New API Video" in output
     assert "youtube-source: new Second API Video" not in output
@@ -1890,3 +1996,162 @@ def test_items_show_rejects_ambiguous_title(tmp_path: Path, capsys) -> None:
     assert "Multiple items share the title" in captured.err
     assert "Daily Briefing (Channel A)" in captured.err
     assert "Daily Briefing (Channel B)" in captured.err
+
+
+def test_source_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
+    parser = build_parser()
+    source_db_path = tmp_path / "source.db"
+    import_db_path = tmp_path / "import.db"
+    export_path = tmp_path / "sources.yaml"
+    repo = Repository(source_db_path)
+    scanned_at = datetime(2026, 4, 18, 12, 30, tzinfo=timezone.utc)
+    repo.upsert_source(
+        SourceConfig(
+            id="yt-1",
+            kind="youtube",
+            name="Example Channel",
+            enabled=False,
+            costs_money=True,
+            feed_url="https://www.youtube.com/watch?v=abc123",
+            handle="@example",
+            transcript_languages=["en", "es"],
+            metadata={"channel_id": "UC123", "num_items": 7},
+        )
+    )
+    repo.mark_source_scan_succeeded("yt-1", scanned_at)
+
+    export_args = parser.parse_args(["--db", str(source_db_path), "source", "export", str(export_path)])
+    assert run(export_args) == 0
+
+    exported = yaml.safe_load(export_path.read_text())
+    assert exported["version"] == 1
+    assert exported["sources"][0]["id"] == "yt-1"
+    assert exported["sources"][0]["last_successful_scan_at"] == scanned_at.isoformat()
+
+    import_args = parser.parse_args(["--db", str(import_db_path), "source", "import", str(export_path)])
+    assert run(import_args) == 0
+
+    imported = Repository(import_db_path).get_source("yt-1")
+    assert imported is not None
+    assert imported.name == "Example Channel"
+    assert imported.enabled is False
+    assert imported.costs_money is True
+    assert imported.transcript_languages == ["en", "es"]
+    assert imported.metadata == {"channel_id": "UC123", "num_items": 7}
+    assert imported.last_successful_scan_at == scanned_at
+
+
+def test_items_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
+    parser = build_parser()
+    source_db_path = tmp_path / "source.db"
+    import_db_path = tmp_path / "import.db"
+    export_path = tmp_path / "items.yaml"
+    repo = Repository(source_db_path)
+    retrieved_at = datetime(2026, 4, 18, 14, 45, tzinfo=timezone.utc)
+    published_at = datetime(2026, 4, 18, 13, 0, tzinfo=timezone.utc)
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="11111111-1111-4111-8111-111111111111",
+            source_id="yt-1",
+            item_type="video",
+            external_id="abc123",
+            canonical_url="https://youtube.com/watch?v=abc123",
+            title="Daily Briefing",
+            author="Channel",
+            published_at=published_at,
+            excerpt="Summary",
+            content_text="Transcript text",
+            content_status=ContentStatus.RATE_LIMITED,
+            content_language="en",
+            content_source="youtube_transcript_api",
+            raw_payload={"video_id": "abc123"},
+            retrieved_at=retrieved_at,
+        )
+    )
+
+    export_args = parser.parse_args(["--db", str(source_db_path), "items", "export", str(export_path)])
+    assert run(export_args) == 0
+
+    exported = yaml.safe_load(export_path.read_text())
+    assert exported["version"] == 1
+    assert exported["items"][0]["item_id"] == "11111111-1111-4111-8111-111111111111"
+    assert exported["items"][0]["retrieved_at"] == retrieved_at.isoformat()
+
+    import_args = parser.parse_args(["--db", str(import_db_path), "items", "import", str(export_path)])
+    assert run(import_args) == 0
+
+    items = Repository(import_db_path).list_items(limit=10)
+    assert len(items) == 1
+    imported = items[0]
+    assert imported.item_id == "11111111-1111-4111-8111-111111111111"
+    assert imported.source_id == "yt-1"
+    assert imported.item_type == "video"
+    assert imported.external_id == "abc123"
+    assert imported.canonical_url == "https://youtube.com/watch?v=abc123"
+    assert imported.title == "Daily Briefing"
+    assert imported.author == "Channel"
+    assert imported.published_at == published_at
+    assert imported.retrieved_at == retrieved_at
+    assert imported.excerpt == "Summary"
+    assert imported.content_text == "Transcript text"
+    assert imported.content_status == ContentStatus.RATE_LIMITED
+    assert imported.content_language == "en"
+    assert imported.content_source == "youtube_transcript_api"
+    assert imported.raw_payload == {"video_id": "abc123"}
+
+
+def test_items_import_updates_existing_entries(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    import_path = tmp_path / "items.yaml"
+    repo = Repository(db_path)
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="11111111-1111-4111-8111-111111111111",
+            source_id="yt-1",
+            item_type="video",
+            external_id="abc123",
+            canonical_url="https://youtube.com/watch?v=abc123",
+            title="Initial Title",
+            author="Channel",
+            published_at=datetime(2026, 4, 18, 13, 0, tzinfo=timezone.utc),
+            excerpt="Summary",
+            content_text="Transcript text",
+        )
+    )
+    import_path.write_text(
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "items": [
+                    {
+                        "item_id": "99999999-9999-4999-8999-999999999999",
+                        "source_id": "yt-1",
+                        "item_type": "video",
+                        "external_id": "abc123",
+                        "canonical_url": "https://youtube.com/watch?v=abc123",
+                        "title": "Updated Title",
+                        "author": "Channel",
+                        "published_at": "2026-04-18T13:00:00+00:00",
+                        "retrieved_at": "2026-04-18T14:00:00+00:00",
+                        "excerpt": "Updated summary",
+                        "content_text": "Updated transcript",
+                        "content_status": "available",
+                        "content_language": "en",
+                        "content_source": "youtube_transcript_api",
+                        "raw_payload": {"video_id": "abc123"},
+                    }
+                ],
+            },
+            sort_keys=False,
+        )
+    )
+
+    import_args = parser.parse_args(["--db", str(db_path), "items", "import", str(import_path)])
+    assert run(import_args) == 0
+
+    items = repo.list_items(limit=10)
+    assert len(items) == 1
+    assert items[0].title == "Updated Title"
+    assert items[0].excerpt == "Updated summary"
+    assert items[0].content_text == "Updated transcript"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,12 +7,15 @@ from pathlib import Path
 from urllib.error import HTTPError
 from uuid import UUID
 
+import pytest
+
 import laminar.adapters as adapters
 import laminar.cli as cli
 from laminar.cli import build_parser, run
-from laminar.models import NormalizedItem, SourceConfig
+from laminar.config import ConfigError
+from laminar.models import ContentStatus, NormalizedItem, SourceConfig
 from laminar.repository import Repository
-from laminar.youtube import TranscriptResult, TranscriptSegment
+from laminar.youtube import TranscriptResult, TranscriptSegment, TranscriptUnavailable
 
 
 def test_scan_and_query(tmp_path: Path) -> None:
@@ -558,6 +561,199 @@ def test_scan_uses_last_successful_scan_time_for_incremental_blog_and_youtube(
         assert fetch_calls == ["new123"]
     finally:
         adapters.fetch_transcript = original_fetch
+
+
+def test_scan_uses_youtube_api_uploads_playlist_metadata(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_source(
+        SourceConfig(
+            id="youtube-source",
+            kind="youtube",
+            name="Example Channel",
+            feed_url="https://www.youtube.com/watch?v=abc123",
+            transcript_languages=["en"],
+            metadata={
+                "channel_id": "UC123",
+                "uploads_playlist_id": "UU123",
+            },
+        )
+    )
+    repo.mark_source_scan_succeeded(
+        "youtube-source",
+        datetime(2026, 4, 14, 12, 30, tzinfo=timezone.utc),
+    )
+
+    original_iter_uploads = adapters.youtube_api.iter_uploads
+    original_fetch = adapters.fetch_transcript
+    fetch_calls: list[str] = []
+
+    def fake_iter_uploads(uploads_playlist_id: str, **kwargs: object):
+        assert uploads_playlist_id == "UU123"
+        assert kwargs["limit"] == 5
+        assert kwargs["page_size"] == 1
+        return iter(
+            [
+                adapters.youtube_api.YouTubeUpload(
+                    video_id="new123",
+                    title="New API Video",
+                    description="Fresh upload",
+                    channel_title="Example Channel",
+                    published_at=datetime(2026, 4, 14, 13, 0, tzinfo=timezone.utc),
+                    canonical_url="https://www.youtube.com/watch?v=new123",
+                ),
+                adapters.youtube_api.YouTubeUpload(
+                    video_id="old123",
+                    title="Old API Video",
+                    description="Older upload",
+                    channel_title="Example Channel",
+                    published_at=datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc),
+                    canonical_url="https://www.youtube.com/watch?v=old123",
+                ),
+            ]
+        )
+
+    def fake_fetch_transcript(
+        video_id_or_url: str,
+        languages: list[str] | None = None,
+    ) -> TranscriptResult:
+        fetch_calls.append(video_id_or_url)
+        assert languages == ["en"]
+        return TranscriptResult(
+            text=f"transcript for {video_id_or_url}",
+            language_code="en",
+            language_name="English",
+            source="youtube_transcript_api_manual",
+            is_generated=False,
+            segments=[
+                TranscriptSegment(
+                    text=f"transcript for {video_id_or_url}",
+                    start=0.0,
+                    duration=1.0,
+                    timestamp="0:00",
+                )
+            ],
+        )
+
+    adapters.youtube_api.iter_uploads = fake_iter_uploads
+    adapters.fetch_transcript = fake_fetch_transcript
+    try:
+        scan_buffer = io.StringIO()
+        with redirect_stdout(scan_buffer):
+            args = parser.parse_args(["--db", str(db_path), "scan", "--source", "youtube"])
+            assert run(args) == 0
+    finally:
+        adapters.youtube_api.iter_uploads = original_iter_uploads
+        adapters.fetch_transcript = original_fetch
+
+    output = scan_buffer.getvalue()
+    assert "Scanning youtube-source (Example Channel)" in output
+    assert "youtube-source: new New API Video" in output
+    assert "youtube-source: new Old API Video" not in output
+    assert fetch_calls == ["new123"]
+
+
+def test_source_add_rejects_invalid_num_items(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+
+    add_args = parser.parse_args(
+        [
+            "--db",
+            str(db_path),
+            "source",
+            "add",
+            "--name",
+            "Example Channel",
+            "--num-items",
+            "0",
+            "https://www.youtube.com/watch?v=abc123",
+        ]
+    )
+
+    with pytest.raises(ConfigError, match="--num-items must be at least 1"):
+        run(add_args)
+
+
+
+def test_scan_stops_after_youtube_transcript_failure(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_source(
+        SourceConfig(
+            id="youtube-source",
+            kind="youtube",
+            name="Example Channel",
+            feed_url="https://www.youtube.com/watch?v=abc123",
+            transcript_languages=["en"],
+            metadata={
+                "channel_id": "UC123",
+                "uploads_playlist_id": "UU123",
+            },
+        )
+    )
+
+    original_iter_uploads = adapters.youtube_api.iter_uploads
+    original_fetch = adapters.fetch_transcript
+    fetch_calls: list[str] = []
+
+    def fake_iter_uploads(uploads_playlist_id: str, **kwargs: object):
+        assert uploads_playlist_id == "UU123"
+        assert kwargs["limit"] == 5
+        assert kwargs["page_size"] == 1
+        return iter(
+            [
+                adapters.youtube_api.YouTubeUpload(
+                    video_id="new123",
+                    title="New API Video",
+                    description="Fresh upload",
+                    channel_title="Example Channel",
+                    published_at=datetime(2026, 4, 14, 13, 0, tzinfo=timezone.utc),
+                    canonical_url="https://www.youtube.com/watch?v=new123",
+                ),
+                adapters.youtube_api.YouTubeUpload(
+                    video_id="next123",
+                    title="Second API Video",
+                    description="Should not be fetched after transcript failure",
+                    channel_title="Example Channel",
+                    published_at=datetime(2026, 4, 14, 12, 0, tzinfo=timezone.utc),
+                    canonical_url="https://www.youtube.com/watch?v=next123",
+                ),
+            ]
+        )
+
+    def fake_fetch_transcript(
+        video_id_or_url: str,
+        languages: list[str] | None = None,
+    ) -> TranscriptResult:
+        fetch_calls.append(video_id_or_url)
+        raise TranscriptUnavailable(
+            "YouTube is receiving too many requests from your IP address",
+            content_status=ContentStatus.RATE_LIMITED,
+        )
+
+    adapters.youtube_api.iter_uploads = fake_iter_uploads
+    adapters.fetch_transcript = fake_fetch_transcript
+    try:
+        scan_buffer = io.StringIO()
+        with redirect_stdout(scan_buffer):
+            args = parser.parse_args(["--db", str(db_path), "scan", "--source", "youtube"])
+            assert run(args) == 0
+    finally:
+        adapters.youtube_api.iter_uploads = original_iter_uploads
+        adapters.fetch_transcript = original_fetch
+
+    output = scan_buffer.getvalue()
+    assert "youtube-source: new New API Video" in output
+    assert "youtube-source: transcript rate-limited for New API Video" in output
+    assert "youtube-source: new Second API Video" not in output
+    stored_items = Repository(db_path).list_items(limit=10)
+    assert len(stored_items) == 1
+    assert stored_items[0].content_status == ContentStatus.RATE_LIMITED
+    assert fetch_calls == ["new123"]
+
 
 
 def test_scan_filters_x_items_using_last_successful_scan_time(tmp_path: Path) -> None:
@@ -1134,30 +1330,83 @@ def test_x_profile_urls_infer_handle(tmp_path: Path) -> None:
     assert sources[0].handle == "example"
 
 
-def test_youtube_urls_infer_youtube_kind(tmp_path: Path) -> None:
+def test_youtube_urls_infer_youtube_kind_and_store_api_metadata(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
+    original_resolve = cli.youtube_api.resolve_channel_from_url
 
-    add_args = parser.parse_args(
-        [
-            "--db",
-            str(db_path),
-            "source",
-            "add",
-            "--name",
-            "Example Channel",
-            "https://www.youtube.com/feeds/videos.xml?channel_id=abc123",
-        ]
-    )
-    assert run(add_args) == 0
+    def fake_resolve_channel_from_url(url: str):
+        assert url == "https://www.youtube.com/watch?v=abc123"
+        return cli.youtube_api.YouTubeChannel(
+            channel_id="UC123",
+            title="Example Channel",
+            uploads_playlist_id="UU123",
+        )
+
+    cli.youtube_api.resolve_channel_from_url = fake_resolve_channel_from_url
+    try:
+        add_args = parser.parse_args(
+            [
+                "--db",
+                str(db_path),
+                "source",
+                "add",
+                "--name",
+                "Example Channel",
+                "https://www.youtube.com/watch?v=abc123",
+            ]
+        )
+        assert run(add_args) == 0
+    finally:
+        cli.youtube_api.resolve_channel_from_url = original_resolve
 
     sources = Repository(db_path).list_sources()
     assert len(sources) == 1
     assert sources[0].kind == "youtube"
     assert sources[0].transcript_languages == ["en"]
+    assert sources[0].metadata["channel_id"] == "UC123"
+    assert sources[0].metadata["uploads_playlist_id"] == "UU123"
+    assert sources[0].metadata["num_items"] == 5
 
 
-def test_regular_youtube_urls_do_not_infer_youtube_kind(tmp_path: Path) -> None:
+def test_youtube_sources_allow_custom_num_items(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    original_resolve = cli.youtube_api.resolve_channel_from_url
+
+    def fake_resolve_channel_from_url(url: str):
+        assert url == "https://www.youtube.com/watch?v=abc123"
+        return cli.youtube_api.YouTubeChannel(
+            channel_id="UC123",
+            title="Example Channel",
+            uploads_playlist_id="UU123",
+        )
+
+    cli.youtube_api.resolve_channel_from_url = fake_resolve_channel_from_url
+    try:
+        add_args = parser.parse_args(
+            [
+                "--db",
+                str(db_path),
+                "source",
+                "add",
+                "--name",
+                "Example Channel",
+                "--num-items",
+                "12",
+                "https://www.youtube.com/watch?v=abc123",
+            ]
+        )
+        assert run(add_args) == 0
+    finally:
+        cli.youtube_api.resolve_channel_from_url = original_resolve
+
+    sources = Repository(db_path).list_sources()
+    assert len(sources) == 1
+    assert sources[0].metadata["num_items"] == 12
+
+
+def test_non_youtube_urls_default_to_feed_kind(tmp_path: Path) -> None:
     parser = build_parser()
     db_path = tmp_path / "laminar.db"
 
@@ -1168,8 +1417,8 @@ def test_regular_youtube_urls_do_not_infer_youtube_kind(tmp_path: Path) -> None:
             "source",
             "add",
             "--name",
-            "Example Video",
-            "https://www.youtube.com/watch?v=abc123",
+            "Example Feed",
+            "https://example.com/feed.xml",
         ]
     )
     assert run(add_args) == 0
@@ -1194,7 +1443,7 @@ def test_youtube_sources_default_transcript_language_to_english(tmp_path: Path) 
             "youtube",
             "--name",
             "Example Channel",
-            "https://www.youtube.com/feeds/videos.xml?channel_id=abc123",
+            "https://example.com/youtube.xml",
         ]
     )
     assert run(add_args) == 0
@@ -1202,6 +1451,7 @@ def test_youtube_sources_default_transcript_language_to_english(tmp_path: Path) 
     sources = Repository(db_path).list_sources()
     assert len(sources) == 1
     assert sources[0].transcript_languages == ["en"]
+    assert sources[0].metadata["num_items"] == 5
 
 
 def test_explicit_type_overrides_url_inference(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2040,6 +2040,28 @@ def test_source_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
     assert imported.last_successful_scan_at == scanned_at
 
 
+def test_source_export_without_path_writes_yaml_to_stdout(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_source(
+        SourceConfig(
+            id="feed-1",
+            kind="feed",
+            name="Example Feed",
+            feed_url="https://example.com/feed.xml",
+        )
+    )
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        export_args = parser.parse_args(["--db", str(db_path), "source", "export"])
+        assert run(export_args) == 0
+
+    exported = yaml.safe_load(buffer.getvalue())
+    assert exported["version"] == 1
+    assert exported["sources"][0]["id"] == "feed-1"
+
+
 def test_items_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
     parser = build_parser()
     source_db_path = tmp_path / "source.db"
@@ -2097,6 +2119,34 @@ def test_items_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
     assert imported.content_language == "en"
     assert imported.content_source == "youtube_transcript_api"
     assert imported.raw_payload == {"video_id": "abc123"}
+
+
+def test_items_export_without_path_writes_yaml_to_stdout(tmp_path: Path) -> None:
+    parser = build_parser()
+    db_path = tmp_path / "laminar.db"
+    repo = Repository(db_path)
+    repo.upsert_item(
+        NormalizedItem(
+            item_id="11111111-1111-4111-8111-111111111111",
+            source_id="yt-1",
+            item_type="video",
+            external_id="abc123",
+            canonical_url="https://youtube.com/watch?v=abc123",
+            title="Daily Briefing",
+            author="Channel",
+            published_at=datetime(2026, 4, 18, 13, 0, tzinfo=timezone.utc),
+            excerpt="Summary",
+            content_text="Transcript text",
+        )
+    )
+
+    with redirect_stdout(io.StringIO()) as buffer:
+        export_args = parser.parse_args(["--db", str(db_path), "items", "export"])
+        assert run(export_args) == 0
+
+    exported = yaml.safe_load(buffer.getvalue())
+    assert exported["version"] == 1
+    assert exported["items"][0]["item_id"] == "11111111-1111-4111-8111-111111111111"
 
 
 def test_items_import_updates_existing_entries(tmp_path: Path) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -199,7 +199,7 @@ def test_scan_and_query(tmp_path: Path) -> None:
     assert "market update" in shown["content_text"]
     assert shown["content_source"] == "youtube_transcript_api_manual"
     assert shown["raw_payload"]["transcript_segments"][0]["timestamp"] == "0:00"
-    assert any(source.costs_money for source in repo.list_sources() if source.kind == "x")
+    assert any(source.paid for source in repo.list_sources() if source.kind == "x")
 
     source_id = next(
         source.id for source in repo.list_sources() if source.name == "Example Channel"
@@ -288,7 +288,7 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
         id="good-source",
         kind="x",
         name="Healthy Feed",
-        costs_money=True,
+        paid=True,
         handle="healthy",
         feed_url="https://x.com/healthy",
     )
@@ -374,7 +374,7 @@ def test_scan_continues_after_source_failure_and_reports_item_statuses(
     assert "Scanning bad-source (Broken Feed)" in output
     assert "bad-source: unreachable - HTTP Error 404: Not Found" in output
     assert "Scanning good-source (Healthy Feed)" in output
-    assert "good-source: this source uses a paid or metered integration" in output
+    assert "good-source: this source is marked paid" in output
     assert "good-source: reachable" in output
     assert "good-source: existing Already seen" in output
     assert "good-source: new Brand new" in output
@@ -406,7 +406,7 @@ def test_scan_skips_paid_sources_without_include_paid(tmp_path: Path) -> None:
             id="paid-source",
             kind="x",
             name="Paid X",
-            costs_money=True,
+            paid=True,
             handle="example",
             feed_url="https://x.com/example",
         )
@@ -1153,7 +1153,7 @@ def test_scan_can_filter_by_source_kind(tmp_path: Path) -> None:
         id="x-source",
         kind="x",
         name="Example X",
-        costs_money=True,
+        paid=True,
         handle="example",
         feed_url="https://x.com/example",
     )
@@ -1411,7 +1411,7 @@ def test_x_sources_default_to_paid(tmp_path: Path) -> None:
 
     assert len(sources) == 1
     assert sources[0].kind == "x"
-    assert sources[0].costs_money is True
+    assert sources[0].paid is True
 
 
 def test_x_profile_urls_infer_handle(tmp_path: Path) -> None:
@@ -1582,7 +1582,7 @@ def test_explicit_type_overrides_url_inference(tmp_path: Path) -> None:
     sources = Repository(db_path).list_sources()
     assert len(sources) == 1
     assert sources[0].kind == "feed"
-    assert sources[0].costs_money is False
+    assert sources[0].paid is False
     assert sources[0].handle is None
 
 
@@ -1682,7 +1682,6 @@ def test_source_add_help_uses_url_type_and_paid_flags(capsys) -> None:
     assert "--kind" not in help_text
     assert "--feed-url" not in help_text
     assert "--command" not in help_text
-    assert "--costs-money" not in help_text
     assert "--handle" not in help_text
 
 
@@ -2011,7 +2010,7 @@ def test_source_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
             kind="youtube",
             name="Example Channel",
             enabled=False,
-            costs_money=True,
+            paid=True,
             feed_url="https://www.youtube.com/watch?v=abc123",
             handle="@example",
             transcript_languages=["en", "es"],
@@ -2035,7 +2034,7 @@ def test_source_export_and_import_round_trip_yaml(tmp_path: Path) -> None:
     assert imported is not None
     assert imported.name == "Example Channel"
     assert imported.enabled is False
-    assert imported.costs_money is True
+    assert imported.paid is True
     assert imported.transcript_languages == ["en", "es"]
     assert imported.metadata == {"channel_id": "UC123", "num_items": 7}
     assert imported.last_successful_scan_at == scanned_at

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -230,7 +230,19 @@ def test_remove_source_requires_recursive_when_items_exist(tmp_path: Path) -> No
 def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
     repo.upsert_source(SourceConfig(id="feed-1", kind="feed", name="Example Feed"))
-    repo.start_scan("feed-1")
+    scan_run_id = repo.start_scan_run(
+        include_paid=False,
+        selected_source_kinds=[],
+        selected_source_ids=[],
+    )
+    repo.record_scan_source(
+        scan_run_id,
+        source=SourceConfig(id="feed-1", kind="feed", name="Example Feed"),
+        status="success",
+        items_seen=0,
+        items_new=0,
+        items_existing=0,
+    )
     repo.upsert_item(
         NormalizedItem(
             source_id="feed-1",
@@ -274,6 +286,159 @@ def test_remove_source_recursive_deletes_source_items_and_scans(tmp_path: Path) 
             "SELECT COUNT(*) FROM scans WHERE source_id = ?",
             ("feed-1",),
         ).fetchone()[0] == 0
+        assert conn.execute(
+            "SELECT COUNT(*) FROM scan_sources WHERE source_id = ?",
+            ("feed-1",),
+        ).fetchone()[0] == 0
+
+
+def test_scan_history_records_run_source_and_item_details(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    source = SourceConfig(id="feed-1", kind="feed", name="Example Feed")
+    repo.upsert_source(source)
+    run_started_at = datetime(2026, 4, 18, 12, 0, tzinfo=timezone.utc)
+    source_started_at = datetime(2026, 4, 18, 12, 1, tzinfo=timezone.utc)
+    source_finished_at = datetime(2026, 4, 18, 12, 2, tzinfo=timezone.utc)
+    run_finished_at = datetime(2026, 4, 18, 12, 3, tzinfo=timezone.utc)
+    cutoff_at = datetime(2026, 4, 17, 8, 0, tzinfo=timezone.utc)
+
+    scan_run_id = repo.start_scan_run(
+        include_paid=True,
+        selected_source_kinds=["feed"],
+        selected_source_ids=["feed-1"],
+        started_at=run_started_at,
+    )
+    scan_source_id = repo.record_scan_source(
+        scan_run_id,
+        source=source,
+        status="success",
+        started_at=source_started_at,
+        finished_at=source_finished_at,
+        cutoff_at=cutoff_at,
+        items_seen=2,
+        items_new=1,
+        items_existing=1,
+    )
+    repo.record_scan_item(
+        scan_source_id,
+        NormalizedItem(
+            item_id="11111111-1111-4111-8111-111111111111",
+            source_id="feed-1",
+            item_type="feed",
+            external_id="post-1",
+            canonical_url="https://example.com/post-1",
+            title="Brand New",
+            author="Author",
+            published_at=datetime(2026, 4, 18, 11, 0, tzinfo=timezone.utc),
+            excerpt="One",
+            content_text="One",
+        ),
+        result="new",
+    )
+    repo.record_scan_item(
+        scan_source_id,
+        NormalizedItem(
+            item_id="22222222-2222-4222-8222-222222222222",
+            source_id="feed-1",
+            item_type="feed",
+            external_id="post-2",
+            canonical_url="https://example.com/post-2",
+            title="Already Seen",
+            author="Author",
+            published_at=datetime(2026, 4, 18, 10, 0, tzinfo=timezone.utc),
+            excerpt="Two",
+            content_text="Two",
+            content_status="missing",
+            content_source="rss",
+        ),
+        result="existing",
+    )
+    repo.finish_scan_run(
+        scan_run_id,
+        status="success",
+        sources_considered=1,
+        sources_scanned=1,
+        sources_skipped=0,
+        sources_failed=0,
+        items_seen=2,
+        items_new=1,
+        items_existing=1,
+        finished_at=run_finished_at,
+    )
+
+    runs = repo.list_scan_runs(limit=10)
+    assert len(runs) == 1
+    assert runs[0].scan_run_id == scan_run_id
+    assert runs[0].status == "success"
+    assert runs[0].include_paid is True
+    assert runs[0].selected_source_kinds == ["feed"]
+    assert runs[0].selected_source_ids == ["feed-1"]
+    assert runs[0].items_existing == 1
+
+    detail = repo.get_scan_run(scan_run_id)
+
+    assert detail is not None
+    assert detail.run.started_at == run_started_at
+    assert detail.run.finished_at == run_finished_at
+    assert len(detail.sources) == 1
+    assert detail.sources[0].source_id == "feed-1"
+    assert detail.sources[0].cutoff_at == cutoff_at
+    assert detail.sources[0].items_new == 1
+    assert detail.sources[0].items_existing == 1
+    assert len(detail.items) == 2
+    assert [item.result for item in detail.items] == ["new", "existing"]
+    assert detail.items[1].content_status.value == "missing"
+
+
+def test_scan_history_persists_skipped_and_failed_sources(tmp_path: Path) -> None:
+    repo = Repository(tmp_path / "laminar.db")
+    skipped = SourceConfig(id="x-1", kind="x", name="Example X", costs_money=True)
+    failed = SourceConfig(id="feed-1", kind="feed", name="Broken Feed")
+    repo.upsert_source(skipped)
+    repo.upsert_source(failed)
+
+    scan_run_id = repo.start_scan_run(
+        include_paid=False,
+        selected_source_kinds=["feed", "x"],
+        selected_source_ids=[],
+    )
+    repo.record_scan_source(
+        scan_run_id,
+        source=skipped,
+        status="skipped",
+        skip_reason="paid_not_included",
+        items_seen=0,
+        items_new=0,
+        items_existing=0,
+    )
+    repo.record_scan_source(
+        scan_run_id,
+        source=failed,
+        status="failed",
+        items_seen=0,
+        items_new=0,
+        items_existing=0,
+        error="HTTP Error 404: Not Found",
+    )
+    repo.finish_scan_run(
+        scan_run_id,
+        status="partial_failure",
+        sources_considered=2,
+        sources_scanned=1,
+        sources_skipped=1,
+        sources_failed=1,
+        items_seen=0,
+        items_new=0,
+        items_existing=0,
+    )
+
+    detail = repo.get_scan_run(scan_run_id)
+
+    assert detail is not None
+    assert detail.run.status == "partial_failure"
+    assert [source.status for source in detail.sources] == ["skipped", "failed"]
+    assert detail.sources[0].skip_reason == "paid_not_included"
+    assert detail.sources[1].error == "HTTP Error 404: Not Found"
 
 
 def test_dedupes_by_canonical_url(tmp_path: Path) -> None:

--- a/tests/test_repository.py
+++ b/tests/test_repository.py
@@ -1,3 +1,4 @@
+import sqlite3
 from datetime import datetime, timezone
 from pathlib import Path
 from uuid import UUID
@@ -16,7 +17,7 @@ def test_persists_source_config_round_trip(tmp_path: Path) -> None:
             kind="youtube",
             name="Example Channel",
             enabled=False,
-            costs_money=True,
+            paid=True,
             feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
             transcript_languages=["en", "es"],
             metadata={"region": "us"},
@@ -28,7 +29,7 @@ def test_persists_source_config_round_trip(tmp_path: Path) -> None:
     assert len(sources) == 1
     assert sources[0].id == "yt-1"
     assert sources[0].enabled is False
-    assert sources[0].costs_money is True
+    assert sources[0].paid is True
     assert sources[0].transcript_languages == ["en", "es"]
     assert sources[0].metadata["region"] == "us"
 
@@ -52,7 +53,7 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
             kind="youtube",
             name="Example Channel",
             enabled=False,
-            costs_money=True,
+            paid=True,
             feed_url="https://www.youtube.com/feeds/videos.xml?channel_id=123",
             handle="@example",
             transcript_languages=["en", "es"],
@@ -67,7 +68,7 @@ def test_get_source_returns_full_source_details(tmp_path: Path) -> None:
     assert source.id == "yt-1"
     assert source.name == "Example Channel"
     assert source.enabled is False
-    assert source.costs_money is True
+    assert source.paid is True
     assert source.feed_url == "https://www.youtube.com/feeds/videos.xml?channel_id=123"
     assert source.handle == "@example"
     assert source.transcript_languages == ["en", "es"]
@@ -84,7 +85,7 @@ def test_stats_reports_totals_by_source_and_kind(tmp_path: Path) -> None:
             id="x-1",
             kind="x",
             name="Example X",
-            costs_money=True,
+            paid=True,
             enabled=False,
         )
     )
@@ -195,7 +196,7 @@ def test_stats_include_items_without_matching_source(tmp_path: Path) -> None:
     assert sources_by_id["missing-source"].name == "[missing source]"
     assert sources_by_id["missing-source"].kind == "missing"
     assert sources_by_id["missing-source"].enabled is False
-    assert sources_by_id["missing-source"].costs_money is False
+    assert sources_by_id["missing-source"].paid is False
     assert sources_by_id["missing-source"].item_count == 1
     assert sources_by_id["missing-source"].size_bytes > 0
     assert kinds_by_name["missing"].source_count == 1
@@ -392,7 +393,7 @@ def test_scan_history_records_run_source_and_item_details(tmp_path: Path) -> Non
 
 def test_scan_history_persists_skipped_and_failed_sources(tmp_path: Path) -> None:
     repo = Repository(tmp_path / "laminar.db")
-    skipped = SourceConfig(id="x-1", kind="x", name="Example X", costs_money=True)
+    skipped = SourceConfig(id="x-1", kind="x", name="Example X", paid=True)
     failed = SourceConfig(id="feed-1", kind="feed", name="Broken Feed")
     repo.upsert_source(skipped)
     repo.upsert_source(failed)

--- a/tests/test_youtube.py
+++ b/tests/test_youtube.py
@@ -1,4 +1,7 @@
-from laminar.youtube import extract_video_id, format_timestamp
+from youtube_transcript_api import _errors as transcript_errors
+
+from laminar.models import ContentStatus
+from laminar.youtube import _status_from_transcript_error, extract_video_id, format_timestamp
 
 
 def test_extract_video_id_from_urls() -> None:
@@ -12,3 +15,11 @@ def test_format_timestamp() -> None:
     assert format_timestamp(0) == "0:00"
     assert format_timestamp(75) == "1:15"
     assert format_timestamp(3670) == "1:01:10"
+
+
+def test_status_from_transcript_error_classifies_missing() -> None:
+    assert _status_from_transcript_error(transcript_errors.NoTranscriptFound("video", [], [])) == ContentStatus.MISSING
+
+
+def test_status_from_transcript_error_classifies_rate_limited() -> None:
+    assert _status_from_transcript_error(transcript_errors.RequestBlocked("too many requests")) == ContentStatus.RATE_LIMITED

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,10 @@
 version = 1
 revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "certifi"
@@ -9,6 +13,76 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -110,12 +184,153 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "46.0.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/93/ac8f3d5ff04d54bc814e961a43ae5b0b146154c89c61b47bb07557679b18/cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5", size = 750652, upload-time = "2026-04-08T01:57:54.692Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/5d/4a8f770695d73be252331e60e526291e3df0c9b27556a90a6b47bccca4c2/cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4", size = 7179869, upload-time = "2026-04-08T01:56:17.157Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/45/6d80dc379b0bbc1f9d1e429f42e4cb9e1d319c7a8201beffd967c516ea01/cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325", size = 4275492, upload-time = "2026-04-08T01:56:19.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/9a/1765afe9f572e239c3469f2cb429f3ba7b31878c893b246b4b2994ffe2fe/cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308", size = 4426670, upload-time = "2026-04-08T01:56:21.415Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/3e/af9246aaf23cd4ee060699adab1e47ced3f5f7e7a8ffdd339f817b446462/cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77", size = 4280275, upload-time = "2026-04-08T01:56:23.539Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/6bbbfc5efe86f9d71041827b793c24811a017c6ac0fd12883e4caa86b8ed/cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1", size = 4928402, upload-time = "2026-04-08T01:56:25.624Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/cf/054b9d8220f81509939599c8bdbc0c408dbd2bdd41688616a20731371fe0/cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef", size = 4459985, upload-time = "2026-04-08T01:56:27.309Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/46/4e4e9c6040fb01c7467d47217d2f882daddeb8828f7df800cb806d8a2288/cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de", size = 3990652, upload-time = "2026-04-08T01:56:29.095Z" },
+    { url = "https://files.pythonhosted.org/packages/36/5f/313586c3be5a2fbe87e4c9a254207b860155a8e1f3cca99f9910008e7d08/cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83", size = 4279805, upload-time = "2026-04-08T01:56:30.928Z" },
+    { url = "https://files.pythonhosted.org/packages/69/33/60dfc4595f334a2082749673386a4d05e4f0cf4df8248e63b2c3437585f2/cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb", size = 4892883, upload-time = "2026-04-08T01:56:32.614Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0b/333ddab4270c4f5b972f980adef4faa66951a4aaf646ca067af597f15563/cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b", size = 4459756, upload-time = "2026-04-08T01:56:34.306Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/633913398b43b75f1234834170947957c6b623d1701ffc7a9600da907e89/cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85", size = 4410244, upload-time = "2026-04-08T01:56:35.977Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f2/19ceb3b3dc14009373432af0c13f46aa08e3ce334ec6eff13492e1812ccd/cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e", size = 4674868, upload-time = "2026-04-08T01:56:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/bb/a5c213c19ee94b15dfccc48f363738633a493812687f5567addbcbba9f6f/cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457", size = 3026504, upload-time = "2026-04-08T01:56:39.666Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/02/7788f9fefa1d060ca68717c3901ae7fffa21ee087a90b7f23c7a603c32ae/cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b", size = 3488363, upload-time = "2026-04-08T01:56:41.893Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/56/15619b210e689c5403bb0540e4cb7dbf11a6bf42e483b7644e471a2812b3/cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842", size = 7119671, upload-time = "2026-04-08T01:56:44Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/e3ce040721b0b5599e175ba91ab08884c75928fbeb74597dd10ef13505d2/cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c", size = 4268551, upload-time = "2026-04-08T01:56:46.071Z" },
+    { url = "https://files.pythonhosted.org/packages/03/11/5e395f961d6868269835dee1bafec6a1ac176505a167f68b7d8818431068/cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902", size = 4408887, upload-time = "2026-04-08T01:56:47.718Z" },
+    { url = "https://files.pythonhosted.org/packages/40/53/8ed1cf4c3b9c8e611e7122fb56f1c32d09e1fff0f1d77e78d9ff7c82653e/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d", size = 4271354, upload-time = "2026-04-08T01:56:49.312Z" },
+    { url = "https://files.pythonhosted.org/packages/50/46/cf71e26025c2e767c5609162c866a78e8a2915bbcfa408b7ca495c6140c4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022", size = 4905845, upload-time = "2026-04-08T01:56:50.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/ea/01276740375bac6249d0a971ebdf6b4dc9ead0ee0a34ef3b5a88c1a9b0d4/cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce", size = 4444641, upload-time = "2026-04-08T01:56:52.882Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4c/7d258f169ae71230f25d9f3d06caabcff8c3baf0978e2b7d65e0acac3827/cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f", size = 3967749, upload-time = "2026-04-08T01:56:54.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2a/2ea0767cad19e71b3530e4cad9605d0b5e338b6a1e72c37c9c1ceb86c333/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99", size = 4270942, upload-time = "2026-04-08T01:56:56.416Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3d/fe14df95a83319af25717677e956567a105bb6ab25641acaa093db79975d/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1", size = 4871079, upload-time = "2026-04-08T01:56:58.31Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/4a479e0f36f8f378d397f4eab4c850b4ffb79a2f0d58704b8fa0703ddc11/cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2", size = 4443999, upload-time = "2026-04-08T01:57:00.508Z" },
+    { url = "https://files.pythonhosted.org/packages/28/17/b59a741645822ec6d04732b43c5d35e4ef58be7bfa84a81e5ae6f05a1d33/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e", size = 4399191, upload-time = "2026-04-08T01:57:02.654Z" },
+    { url = "https://files.pythonhosted.org/packages/59/6a/bb2e166d6d0e0955f1e9ff70f10ec4b2824c9cfcdb4da772c7dd69cc7d80/cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee", size = 4655782, upload-time = "2026-04-08T01:57:04.592Z" },
+    { url = "https://files.pythonhosted.org/packages/95/b6/3da51d48415bcb63b00dc17c2eff3a651b7c4fed484308d0f19b30e8cb2c/cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298", size = 3002227, upload-time = "2026-04-08T01:57:06.91Z" },
+    { url = "https://files.pythonhosted.org/packages/32/a8/9f0e4ed57ec9cebe506e58db11ae472972ecb0c659e4d52bbaee80ca340a/cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb", size = 3475332, upload-time = "2026-04-08T01:57:08.807Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/7f/cd42fc3614386bc0c12f0cb3c4ae1fc2bbca5c9662dfed031514911d513d/cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4", size = 7165618, upload-time = "2026-04-08T01:57:10.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/d0/36a49f0262d2319139d2829f773f1b97ef8aef7f97e6e5bd21455e5a8fb5/cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7", size = 4270628, upload-time = "2026-04-08T01:57:12.885Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6c/1a42450f464dda6ffbe578a911f773e54dd48c10f9895a23a7e88b3e7db5/cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832", size = 4415405, upload-time = "2026-04-08T01:57:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/92/4ed714dbe93a066dc1f4b4581a464d2d7dbec9046f7c8b7016f5286329e2/cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163", size = 4272715, upload-time = "2026-04-08T01:57:16.638Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e6/a26b84096eddd51494bba19111f8fffe976f6a09f132706f8f1bf03f51f7/cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2", size = 4918400, upload-time = "2026-04-08T01:57:19.021Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/08/ffd537b605568a148543ac3c2b239708ae0bd635064bab41359252ef88ed/cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067", size = 4450634, upload-time = "2026-04-08T01:57:21.185Z" },
+    { url = "https://files.pythonhosted.org/packages/16/01/0cd51dd86ab5b9befe0d031e276510491976c3a80e9f6e31810cce46c4ad/cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0", size = 3985233, upload-time = "2026-04-08T01:57:22.862Z" },
+    { url = "https://files.pythonhosted.org/packages/92/49/819d6ed3a7d9349c2939f81b500a738cb733ab62fbecdbc1e38e83d45e12/cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba", size = 4271955, upload-time = "2026-04-08T01:57:24.814Z" },
+    { url = "https://files.pythonhosted.org/packages/80/07/ad9b3c56ebb95ed2473d46df0847357e01583f4c52a85754d1a55e29e4d0/cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006", size = 4879888, upload-time = "2026-04-08T01:57:26.88Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c7/201d3d58f30c4c2bdbe9b03844c291feb77c20511cc3586daf7edc12a47b/cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0", size = 4449961, upload-time = "2026-04-08T01:57:29.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ef/649750cbf96f3033c3c976e112265c33906f8e462291a33d77f90356548c/cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85", size = 4401696, upload-time = "2026-04-08T01:57:31.029Z" },
+    { url = "https://files.pythonhosted.org/packages/41/52/a8908dcb1a389a459a29008c29966c1d552588d4ae6d43f3a1a4512e0ebe/cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e", size = 4664256, upload-time = "2026-04-08T01:57:33.144Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/fa/f0ab06238e899cc3fb332623f337a7364f36f4bb3f2534c2bb95a35b132c/cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246", size = 3013001, upload-time = "2026-04-08T01:57:34.933Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/f1/00ce3bde3ca542d1acd8f8cfa38e446840945aa6363f9b74746394b14127/cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3", size = 3472985, upload-time = "2026-04-08T01:57:36.714Z" },
+    { url = "https://files.pythonhosted.org/packages/63/0c/dca8abb64e7ca4f6b2978769f6fea5ad06686a190cec381f0a796fdcaaba/cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f", size = 3476879, upload-time = "2026-04-08T01:57:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ea/075aac6a84b7c271578d81a2f9968acb6e273002408729f2ddff517fed4a/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15", size = 4219700, upload-time = "2026-04-08T01:57:40.625Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7b/1c55db7242b5e5612b29fc7a630e91ee7a6e3c8e7bf5406d22e206875fbd/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455", size = 4385982, upload-time = "2026-04-08T01:57:42.725Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
+]
+
+[[package]]
 name = "defusedxml"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.30.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/16/ce/502a57fb0ec752026d24df1280b162294b22a0afb98a326084f9a979138b/google_api_core-2.30.3.tar.gz", hash = "sha256:e601a37f148585319b26db36e219df68c5d07b6382cff2d580e83404e44d641b", size = 177001, upload-time = "2026-04-10T00:41:28.035Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/15/e56f351cf6ef1cfea58e6ac226a7318ed1deb2218c4b3cc9bd9e4b786c5a/google_api_core-2.30.3-py3-none-any.whl", hash = "sha256:a85761ba72c444dad5d611c2220633480b2b6be2521eca69cca2dbb3ffd6bfe8", size = 173274, upload-time = "2026-04-09T22:57:16.198Z" },
+]
+
+[[package]]
+name = "google-api-python-client"
+version = "2.194.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-auth-httplib2" },
+    { name = "httplib2" },
+    { name = "uritemplate" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/ab/e83af0eb043e4ccc49571ca7a6a49984e9d00f4e9e6e6f1238d60bc84dce/google_api_python_client-2.194.0.tar.gz", hash = "sha256:db92647bd1a90f40b79c9618461553c2b20b6a43ce7395fa6de07132dc14f023", size = 14443469, upload-time = "2026-04-08T23:07:35.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/34/5a624e49f179aa5b0cb87b2ce8093960299030ff40423bfbde09360eb908/google_api_python_client-2.194.0-py3-none-any.whl", hash = "sha256:61eaaac3b8fc8fdf11c08af87abc3d1342d1b37319cc1b57405f86ef7697e717", size = 15016514, upload-time = "2026-04-08T23:07:33.093Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[[package]]
+name = "google-auth-httplib2"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "httplib2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/99/107612bef8d24b298bb5a7c8466f908ecda791d43f9466f5c3978f5b24c1/google_auth_httplib2-0.3.1.tar.gz", hash = "sha256:0af542e815784cb64159b4469aa5d71dd41069ba93effa006e1916b1dcd88e55", size = 11152, upload-time = "2026-03-30T22:50:26.766Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/e9/93afb14d23a949acaa3f4e7cc51a0024671174e116e35f42850764b99634/google_auth_httplib2-0.3.1-py3-none-any.whl", hash = "sha256:682356a90ef4ba3d06548c37e9112eea6fc00395a11b0303a644c1a86abc275c", size = 9534, upload-time = "2026-03-30T22:49:03.384Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
+name = "httplib2"
+version = "0.31.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyparsing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c1/1f/e86365613582c027dda5ddb64e1010e57a3d53e99ab8a72093fa13d565ec/httplib2-0.31.2.tar.gz", hash = "sha256:385e0869d7397484f4eab426197a4c020b606edd43372492337c0b4010ae5d24", size = 250800, upload-time = "2026-01-23T11:04:44.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/90/fd509079dfcab01102c0fdd87f3a9506894bc70afcf9e9785ef6b2b3aff6/httplib2-0.31.2-py3-none-any.whl", hash = "sha256:dbf0c2fa3862acf3c55c078ea9c0bc4481d7dc5117cae71be9514912cf9f8349", size = 91099, upload-time = "2026-01-23T11:04:42.78Z" },
 ]
 
 [[package]]
@@ -141,6 +356,7 @@ name = "laminar"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "google-api-python-client" },
     { name = "pyyaml" },
     { name = "rich" },
     { name = "youtube-transcript-api" },
@@ -153,6 +369,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "google-api-python-client", specifier = ">=2.194.0" },
     { name = "pyyaml", specifier = ">=6,<7" },
     { name = "rich", specifier = ">=14.1,<15" },
     { name = "youtube-transcript-api", specifier = ">=1.2.4,<2" },
@@ -201,12 +418,78 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/0d/94dfe80193e79d55258345901acd2917523d56e8381bc4dee7fd38e3868a/proto_plus-1.27.2.tar.gz", hash = "sha256:b2adde53adadf75737c44d3dcb0104fde65250dfc83ad59168b4aa3e574b6a24", size = 57204, upload-time = "2026-03-26T22:18:57.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/f3/1fba73eeffafc998a25d59703b63f8be4fe8a5cb12eaff7386a0ba0f7125/proto_plus-1.27.2-py3-none-any.whl", hash = "sha256:6432f75893d3b9e70b9c412f1d2f03f65b11fb164b793d14ae2ca01821d22718", size = 50450, upload-time = "2026-03-26T22:13:42.927Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.34.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/6b/a0e95cad1ad7cc3f2c6821fcab91671bd5b78bd42afb357bb4765f29bc41/protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280", size = 454708, upload-time = "2026-03-20T17:34:47.036Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/11/3325d41e6ee15bf1125654301211247b042563bcc898784351252549a8ad/protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7", size = 429247, upload-time = "2026-03-20T17:34:37.024Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/9d/aa69df2724ff63efa6f72307b483ce0827f4347cc6d6df24b59e26659fef/protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b", size = 325753, upload-time = "2026-03-20T17:34:38.751Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e8/d174c91fd48e50101943f042b09af9029064810b734e4160bbe282fa1caa/protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a", size = 340198, upload-time = "2026-03-20T17:34:39.871Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1b/3b431694a4dc6d37b9f653f0c64b0a0d9ec074ee810710c0c3da21d67ba7/protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4", size = 324267, upload-time = "2026-03-20T17:34:41.1Z" },
+    { url = "https://files.pythonhosted.org/packages/85/29/64de04a0ac142fb685fd09999bc3d337943fb386f3a0ec57f92fd8203f97/protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a", size = 426628, upload-time = "2026-03-20T17:34:42.536Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/87/cb5e585192a22b8bd457df5a2c16a75ea0db9674c3a0a39fc9347d84e075/protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c", size = 437901, upload-time = "2026-03-20T17:34:44.112Z" },
+    { url = "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11", size = 170715, upload-time = "2026-03-20T17:34:45.384Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyparsing"
+version = "3.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
 ]
 
 [[package]]
@@ -306,6 +589,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e9/67/cae617f1351490c25a4b8ac3b8b63a4dda609295d8222bad12242dfdc629/rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9", size = 230524, upload-time = "2026-04-11T02:57:45.419Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/76/6d163cfac87b632216f71879e6b2cf17163f773ff59c00b5ff4900a80fa3/rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952", size = 310480, upload-time = "2026-04-11T02:57:47.484Z" },
+]
+
+[[package]]
+name = "uritemplate"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/60/f174043244c5306c9988380d2cb10009f91563fc4b31293d27e17201af56/uritemplate-4.2.0.tar.gz", hash = "sha256:480c2ed180878955863323eea31b0ede668795de182617fef9c6ca09e6ec9d0e", size = 33267, upload-time = "2025-06-02T15:12:06.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/99/3ae339466c9183ea5b8ae87b34c0b897eda475d2aec2307cae60e5cd4f29/uritemplate-4.2.0-py3-none-any.whl", hash = "sha256:962201ba1c4edcab02e60f9a0d3821e82dfc5d2d6662a21abd533879bdb8a686", size = 11488, upload-time = "2025-06-02T15:12:03.405Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add source and item YAML export/import commands, with export-to-stdout support
- add durable scan history commands and reporting
- switch YouTube source resolution and scanning to the YouTube Data API
- rename the paid source field/terminology and update docs/skill guidance

## Validation
- UV_CACHE_DIR=.uv-cache uv run pytest